### PR TITLE
Use c_long for timeval

### DIFF
--- a/evdev-sys/build.rs
+++ b/evdev-sys/build.rs
@@ -54,6 +54,11 @@ fn main() {
        .arg(src.join("libevdev/autogen.sh").to_str().unwrap()
                .replace("C:\\", "/c/")
                .replace("\\", "/"));
+    match env::var("HOST") {
+        Ok(h) => { cmd.arg(format!("--host={}", h)); },
+        Err(_) => {}
+    }
+
     cmd.arg(format!("--prefix={}", sanitize_sh(&dst)));
 
     run(&mut cmd);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod util;
 #[macro_use]
 mod macros;
 
-use libc::{c_char, c_int, c_uint, c_void};
+use libc::{c_char, c_int, c_long, c_uint, c_void};
 use nix::errno::Errno;
 use std::any::Any;
 use std::ffi::{CStr, CString};
@@ -135,8 +135,8 @@ pub struct Device {
 }
 
 pub struct TimeVal {
-   pub tv_sec: i64,
-   pub tv_usec: i64,
+   pub tv_sec: c_long,
+   pub tv_usec: c_long,
 }
 
 /// The event structure itself


### PR DESCRIPTION
In order to have evdev-rs compile on all architectures, we have
to use c_long instead of just i64.

(I needed to make this commit to make evdev-rs compile on my raspberry pi.)