### PR TITLE
Fix "use of a deprecated item" build warning.

### DIFF
--- a/evdev-sys/Cargo.toml
+++ b/evdev-sys/Cargo.toml
@@ -18,4 +18,4 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
-gcc = "0.3"
+cc = "1.0"

--- a/evdev-sys/build.rs
+++ b/evdev-sys/build.rs
@@ -1,5 +1,5 @@
 extern crate pkg_config;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::ffi::OsString;
@@ -37,7 +37,7 @@ fn main() {
     println!("cargo:rerun-if-changed=libevdev/autogen.sh");
 
     println!("cargo:rustc-link-lib=static=evdev");
-    let cfg = gcc::Build::new();
+    let cfg = cc::Build::new();
     let compiler = cfg.get_compiler();
 
     let _ = fs::create_dir(&dst.join("build"));


### PR DESCRIPTION
This is a minor fix that resolves a build warning:
```
warning: use of deprecated item 'gcc::Build': crate has been renamed to `cc`, the `gcc` name is not maintained
```

I'm brand new to the world of Rust, so this patch was written with the help of Google. Please modify as need.