### PR TITLE
Automatically derive `Eq` and `Hash` traits for event enums

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,7 +1,7 @@
 /* THIS FILE IS GENERATED, DO NOT EDIT */
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EventType {
     EV_SYN = 0,
     EV_KEY = 1,
@@ -56,7 +56,7 @@ pub enum EventCode {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_REL {
     REL_X = 0,
     REL_Y = 1,
@@ -89,7 +89,7 @@ pub fn int_to_ev_rel(code: u32) -> Option<EV_REL> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_ABS {
     ABS_X = 0,
     ABS_Y = 1,
@@ -184,7 +184,7 @@ pub fn int_to_ev_abs(code: u32) -> Option<EV_ABS> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_KEY {
     KEY_RESERVED = 0,
     KEY_ESC = 1,
@@ -1285,7 +1285,7 @@ pub fn int_to_ev_key(code: u32) -> Option<EV_KEY> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_LED {
     LED_NUML = 0,
     LED_CAPSL = 1,
@@ -1320,7 +1320,7 @@ pub fn int_to_ev_led(code: u32) -> Option<EV_LED> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SND {
     SND_CLICK = 0,
     SND_BELL = 1,
@@ -1339,7 +1339,7 @@ pub fn int_to_ev_snd(code: u32) -> Option<EV_SND> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_MSC {
     MSC_SERIAL = 0,
     MSC_PULSELED = 1,
@@ -1364,7 +1364,7 @@ pub fn int_to_ev_msc(code: u32) -> Option<EV_MSC> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SW {
     SW_LID = 0,
     SW_TABLET_MODE = 1,
@@ -1407,7 +1407,7 @@ pub fn int_to_ev_sw(code: u32) -> Option<EV_SW> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SYN {
     SYN_REPORT = 0,
     SYN_CONFIG = 1,
@@ -1428,7 +1428,7 @@ pub fn int_to_ev_syn(code: u32) -> Option<EV_SYN> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_REP {
     REP_DELAY = 0,
     REP_MAX = 1,
@@ -1443,7 +1443,7 @@ pub fn int_to_ev_rep(code: u32) -> Option<EV_REP> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum InputProp {
     INPUT_PROP_POINTER = 0,
     INPUT_PROP_DIRECT = 1,
@@ -1470,7 +1470,7 @@ pub fn int_to_input_prop(code: u32) -> Option<InputProp> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_FF {
     FF_STATUS_STOPPED = 0,
     FF_STATUS_MAX = 1,
@@ -1519,7 +1519,7 @@ pub fn int_to_ev_ff(code: u32) -> Option<EV_FF> {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BusType {
     BUS_PCI = 1,
     BUS_ISAPNP = 2,

--- a/tools/make-event-names.py
+++ b/tools/make-event-names.py
@@ -82,7 +82,7 @@ def print_enums(bits, prefix):
                 return
 
         print("#[allow(non_camel_case_types)]")
-        print("#[derive(Clone, Debug, PartialEq)]")
+        print("#[derive(Clone, Debug, PartialEq, Eq, Hash)]")
         print("pub enum %s {" % enum_name)
         for val, name in list(getattr(bits, prefix).items()):
                 print("    %s = %s," % (name, val))


### PR DESCRIPTION
For context, I needed `Eq` and `Hash` implemented for the `EV_KEY` enum in order to write code that looks like this:
```
HashMap<evdev::enums::EV_KEY, (usize, usize)>
```
For completeness, I added these traits to all the various event type enums. Edits are welcome...