### PR TITLE
feat: handle file descriptor in device

### DIFF
--- a/examples/evtest.rs
+++ b/examples/evtest.rs
@@ -117,7 +117,7 @@ fn main() {
     let f = File::open(path).unwrap();
 
     let mut d = Device::new().unwrap();
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
 
     println!("Input device ID: bus 0x{:x} vendor 0x{:x} product 0x{:x}",
 			d.bustype(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! let f = File::open("/dev/input/event0").unwrap();
 //!
 //! let mut d = Device::new().unwrap();
-//! d.set_fd(&f).unwrap();
+//! d.set_fd(f).unwrap();
 //! ```
 //!
 //! ## Getting the next event
@@ -26,7 +26,7 @@
 //! let f = File::open("/dev/input/event0").unwrap();
 //!
 //! let mut d = Device::new().unwrap();
-//! d.set_fd(&f).unwrap();
+//! d.set_fd(f).unwrap();
 //!
 //! loop {
 //!     let a = d.next_event(evdev_rs::NORMAL | evdev_rs::BLOCKING);

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -14,7 +14,7 @@ fn context_create() {
 #[test]
 fn context_create_with_fd() {
     let f = File::open("/dev/input/event0").unwrap();
-    let _d = Device::new_from_fd(&f).unwrap();
+    let _d = Device::new_from_fd(f).unwrap();
 }
 
 #[test]
@@ -22,7 +22,7 @@ fn context_set_fd() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    match d.set_fd(&f) {
+    match d.set_fd(f) {
         Ok(()) => ..,
         Err(result) => panic!("Error {}", result.desc()),
     };
@@ -33,14 +33,15 @@ fn context_change_fd() {
     let mut d = Device::new().unwrap();
     let f1 = File::open("/dev/input/event0").unwrap();
     let f2 = File::open("/dev/input/event0").unwrap();
+    let f2_fd = f2.as_raw_fd();
 
-    d.set_fd(&f1).unwrap();
-    match d.change_fd(&f2) {
+    d.set_fd(f1).unwrap();
+    match d.change_fd(f2) {
         Ok(()) => ..,
         Err(result) => panic!("Error {}", result),
     };
 
-    assert_eq!(d.fd().unwrap().as_raw_fd(), f2.as_raw_fd());
+    assert_eq!(d.fd().unwrap().as_raw_fd(), f2_fd);
 }
 
 #[test]
@@ -48,7 +49,7 @@ fn context_grab() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
     d.grab(GrabMode::Grab).unwrap();
     d.grab(GrabMode::Ungrab).unwrap();
 }
@@ -114,7 +115,7 @@ fn device_get_absinfo() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
     for code in EventCode::EV_SYN(EV_SYN::SYN_REPORT).iter() {
         let absinfo: Option<AbsInfo> = d.abs_info(&code);
 
@@ -130,7 +131,7 @@ fn device_has_property() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
     for prop in InputProp::INPUT_PROP_POINTER.iter() {
         if d.has(&prop) {
             panic!("Prop {} is set, shouldn't be", prop);
@@ -143,7 +144,7 @@ fn device_has_syn() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
 
     assert!(d.has(&EventType::EV_SYN)); // EV_SYN
     assert!(d.has(&EventCode::EV_SYN(EV_SYN::SYN_REPORT))); // SYN_REPORT
@@ -154,7 +155,7 @@ fn device_get_value() {
     let mut d = Device::new().unwrap();
     let f = File::open("/dev/input/event0").unwrap();
 
-    d.set_fd(&f).unwrap();
+    d.set_fd(f).unwrap();
 
     let v2 = d.event_value(&EventCode::EV_SYN(EV_SYN::SYN_REPORT)); // SYN_REPORT
     assert_eq!(v2, Some(0));


### PR DESCRIPTION
While using this crate, I've noticed that whenever I create a `Device`, I must ensure that the `File` it was created from lives longer than the `Device`, otherwise `EBADF` errors are thrown.

This change makes the `Device` struct take ownership of its `File`.
Devices created with libevdev require that their file descriptors are not freed while the device is active. 

Now, the `Device` struct will take ownership of the `File`, so that the user of the library does not have to worry about this quirk.

---

I'm open to suggestions on better ways to do this if you have any. :)