### PR TITLE
Fix panic with known event_type but unknown event_code

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -97,7 +97,7 @@ pub fn event_code_to_int(event_code: &EventCode) -> (c_uint, c_uint) {
 pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> Option<EventCode> {
     let ev_type: EventType = int_to_event_type(event_type as u32).unwrap();
 
-    match ev_type {
+    let ev_code = match ev_type {
         EventType::EV_SYN =>    match int_to_ev_syn(event_code as u32) {
                                     None => None,
                                     Some(k) => Some(EventCode::EV_SYN(k)),
@@ -144,11 +144,16 @@ pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> Option<Event
                                     None => None,
                                     Some(k) => Some(EventCode::EV_FF_STATUS(k)),
                                 },
-        EventType::EV_UNK =>    Some(EventCode::EV_UNK {
-                                    event_type: event_type as u32,
-                                    event_code: event_code as u32,
-                                }),
+        EventType::EV_UNK =>    None,
         EventType::EV_MAX =>    Some(EventCode::EV_MAX),
+    };
+
+    match ev_code {
+        Some(_) => ev_code,
+        None => Some(EventCode::EV_UNK {
+            event_type: event_type as u32,
+            event_code: event_code as u32,
+        }),
     }
 }
 


### PR DESCRIPTION
As mentioned in [my comment](https://github.com/ndesh26/evdev-rs/issues/23#issuecomment-546359691) on #23, this PR prevents panics on events like `event_type: 2, event_code: 11` (which occur when scrolling on new Linux kernels). 

I've [modified](https://github.com/tehwalris/evdev-rs/commit/2cb1de0d84f717a95f011c72706982b77255b670) `int_to_event_code` so that it returns an unknown event code in this case. This prevents panics in the spirit of the [previous fix](https://github.com/ndesh26/evdev-rs/commit/c82e7b3a53f3641cc893b84ad08aa4242f451089). However it means that `event_code` and `event_type` no longer match for unknown events: 

```
InputEvent { time: TimeVal { tv_sec: 1572010534, tv_usec: 154983 }, event_type: EV_REL, event_code: EV_UNK { event_type: 2, event_code: 11 }, value: -120 }
```

Also since `int_to_event_code` will now never return `None`, I think its signature should be changed so that it doesn't return an `Option`.