### PR TITLE
Remove Option from return value of int_to_event_code

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -699,7 +699,7 @@ impl Device {
                 tv_usec: ev.time.tv_usec,
             },
             event_type: int_to_event_type(ev.type_ as u32).unwrap(),
-            event_code: int_to_event_code(ev.type_ as u32, ev.code as u32).unwrap(),
+            event_code: int_to_event_code(ev.type_ as u32, ev.code as u32),
             value: ev.value,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl InputEvent {
     pub fn from_raw(event: &libc::input_event) -> InputEvent {
         let ev_type = event.type_ as u32;
         let event_type = int_to_event_type(ev_type).unwrap();
-        let event_code = int_to_event_code(ev_type, event.code as u32).unwrap();
+        let event_code = int_to_event_code(ev_type, event.code as u32);
         InputEvent {
             time: TimeVal::from_raw(&event.time),
             event_type,

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,7 +94,7 @@ pub fn event_code_to_int(event_code: &EventCode) -> (c_uint, c_uint) {
 
 }
 
-pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> Option<EventCode> {
+pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
     let ev_type: EventType = int_to_event_type(event_type as u32).unwrap();
 
     let ev_code = match ev_type {
@@ -149,11 +149,11 @@ pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> Option<Event
     };
 
     match ev_code {
-        Some(_) => ev_code,
-        None => Some(EventCode::EV_UNK {
+        Some(c) => c,
+        None => EventCode::EV_UNK {
             event_type: event_type as u32,
             event_code: event_code as u32,
-        }),
+        },
     }
 }
 
@@ -231,7 +231,7 @@ impl EventCode {
 
         match result {
             -1 => None,
-             k => int_to_event_code(ev_type.clone() as u32, k as u32),
+             k => Some(int_to_event_code(ev_type.clone() as u32, k as u32)),
         }
     }
 }


### PR DESCRIPTION
As discussed in #25, the Option returned by `int_to_event_code` can now never be `None`, so this PR removes it.