### PR TITLE
Fixed constructing TimeVal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub struct TimeVal {
 }
 
 impl TimeVal {
-    pub fn new(tv_sec: i64, tv_usec: i64) -> TimeVal {
+    pub fn new(tv_sec: c_long, tv_usec: c_long) -> TimeVal {
         TimeVal { tv_sec, tv_usec }
     }
 


### PR DESCRIPTION
On some targets (e.g. armv7-unknown-linux, rpi3b+) `c_long` != `i64`. Used `c_long` for constructing `TimeVal` instead `i64`.