### PR TITLE
impl std::convert::TryFrom<std::time::SystemTime> for TimeVal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,8 @@ pub mod uinput;
 pub mod util;
 
 use libc::{c_long, c_uint};
+use std::convert::TryFrom;
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
 use enums::*;
 use util::*;
@@ -157,8 +159,19 @@ impl AbsInfo {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TimeVal {
-   pub tv_sec: c_long,
-   pub tv_usec: c_long,
+    pub tv_sec: c_long,
+    pub tv_usec: c_long,
+}
+
+impl TryFrom<SystemTime> for TimeVal {
+    type Error = SystemTimeError;
+    fn try_from(system_time: SystemTime) -> Result<Self, Self::Error> {
+        let d = system_time.duration_since(UNIX_EPOCH)?;
+        Ok(TimeVal {
+            tv_sec: d.as_secs() as i64,
+            tv_usec: d.subsec_micros() as i64,
+        })
+    }
 }
 
 impl TimeVal {


### PR DESCRIPTION
I need to generate a `UInputEvent` in a userspace keyboard remapping tool that I am hacking on. Because of this I need to create `TimeVal` instance, but I also anticipate the possibiilty of having to do this more in the future as my tool grows in functionality. So my options to make my `TimeVal` creation reuable are:

* Implement a utility function in my tool's library
* Implement a `TimeVal::now()` function
* Always just use `TimeValue::new(...)`
* Implement `std::convert::TryFrom<std::time::SystemTime> for TimeVal` as in this PR.

I don't like the first option because it won't be reusable for the next person that runs into this problem.

I don't like the second option because it assumes the only `TimeVal` anyone would want to create is `now()` and not, say, yesterday or tomorrow or five seconds ago.

I don't like the third option because it means I have to calculate the time since `UNIX_EPOCH` then call the correct `std::time::Duration` methods on the result to get the seconds and fractional microseconds values.

I do like fourth third option because it allows the compiler to "implicitly" convert `std::time::SystemTime` into a `TimeVal` which keeps my code clean and it becomes available for future users of this library.

Thanks for your consideration!