### PR TITLE
use std::io::Error instead of nix::errno::Errno

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ a library interface to the callers, thus avoiding erroneous ioctls, etc.
 
 [dependencies]
 evdev-sys = { path = "evdev-sys", version = "0.2.0" }
-nix = "0.17.0"
 libc = "0.2.67"
 bitflags = "1.2.1"
 log = "0.4.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@
 //! ```
 
 extern crate evdev_sys as raw;
-extern crate nix;
 extern crate libc;
 #[macro_use]
 extern crate bitflags;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,13 +51,13 @@ macro_rules! abs_getter {
     ( $( $func_name:ident, $c_func: ident ),* ) => {
         $(
             pub fn $func_name (&self,
-                               code: u32) -> Result<i32, nix::errno::Errno> {
+                               code: u32) -> std::io::Result<i32> {
                 let result = unsafe {
                     raw::$c_func(self.raw, code as c_uint) as i32
                 };
 
                 match result {
-                    0 => Err(nix::errno::from_i32(0)),
+                    0 => Err(std::io::Error::from_raw_os_error(0)),
                     k => Ok(k)
                 }
             }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -24,7 +24,7 @@ fn context_set_fd() {
 
     match d.set_fd(f) {
         Ok(()) => ..,
-        Err(result) => panic!("Error {}", result.desc()),
+        Err(result) => panic!("Error {}", result),
     };
 }
 


### PR DESCRIPTION
This PR replaces the error type in the binding functions from `nix::errno::Errno` to `std::io::Error`, and removes the unnecessary `nix` dependency from dependencies.

The motivations for providing this patch are as follows:

* By using the stable type provided by the Rust's standard library, it is possible to suppress the verbose API changes due to the major changes of dependent crates.

* Most of the features provided by `nix` except the definition of errno are unrelated to the implementation of this library.  Since the dependency on `nix` can be *completely* removed by replacing the error type of bindings, the compile-time costs (like build time) are able to be reduced when the library user side does not depend on `nix`.