### PR TITLE
Various style and minor functionality tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/ndesh26/evdev-rs"
 homepage = "https://github.com/ndesh26/evdev-rs"
 documentation = "http://ndesh26.github.io/evdev-rs"
+edition = "2018"
 description = """
 Bindings to libevdev for interacting with evdev devices. It moves the
 common tasks when dealing with evdev devices into a library and provides

--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,8 @@
     * `void libevdev_set_log_function(libevdev_log_func_t logfunc, void *data);`
 * libevdev_device_log_func_t
     * `void libevdev_set_device_log_function(struct libevdev *dev,
-				      libevdev_device_log_func_t logfunc,
-				      enum libevdev_log_priority priority,
-				      void *data);`
+                      libevdev_device_log_func_t logfunc,
+                      enum libevdev_log_priority priority,
+                      void *data);`
 
 ## Add Documentation

--- a/evdev-sys/Cargo.toml
+++ b/evdev-sys/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT/Apache-2.0"
 keywords = ["evdev"]
 links = "evdev"
 repository = "https://github.com/ndesh26/evdev-rs"
+edition = "2018"
 description = """
 Raw bindings to libevdev
 

--- a/evdev-sys/src/lib.rs
+++ b/evdev-sys/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 #![allow(improper_ctypes)]
 
-extern crate libc;
-
 use libc::{c_int, c_uint, c_char, c_void, size_t};
 pub use libc::{timeval, input_event, input_absinfo};
 

--- a/examples/evtest.rs
+++ b/examples/evtest.rs
@@ -1,7 +1,5 @@
-extern crate evdev_rs as evdev;
-
-use evdev::*;
-use evdev::enums::*;
+use evdev_rs::*;
+use evdev_rs::enums::*;
 use std::io;
 use std::fs::File;
 
@@ -13,21 +11,21 @@ fn print_abs_bits(dev: &Device, axis: &EV_ABS) {
 
     let code = EventCode::EV_ABS(axis.clone());
 
-	if !dev.has(&code) { return; }
+    if !dev.has(&code) { return; }
 
-	let abs = dev.abs_info(&code).unwrap();
+    let abs = dev.abs_info(&code).unwrap();
 
-	println!("	Value	{}", abs.value);
-	println!("	Min	{}", abs.minimum);
-	println!("	Max	{}", abs.maximum);
-	if abs.fuzz != 0 {
-		println!("	Fuzz	{}", abs.fuzz);
+    println!("\tValue\t{}", abs.value);
+    println!("\tMin\t{}", abs.minimum);
+    println!("\tMax\t{}", abs.maximum);
+    if abs.fuzz != 0 {
+    println!("\tFuzz\t{}", abs.fuzz);
     }
-	if abs.flat != 0 {
-		println!("	Flat	{}", abs.flat);
+    if abs.flat != 0 {
+    println!("\tFlat\t{}", abs.flat);
     }
-	if abs.resolution != 0 {
-		println!("	Resolution	{}", abs.resolution);
+    if abs.resolution != 0 {
+        println!("\tResolution\t{}", abs.resolution);
     }
 }
 
@@ -40,7 +38,7 @@ fn print_code_bits(dev: &Device, ev_code: &EventCode, max: &EventCode) {
             continue;
         }
 
-		println!("    Event code: {}", code);
+        println!("    Event code: {}", code);
         match code {
             EventCode::EV_ABS(k) => print_abs_bits(dev, &k),
             _ => ()
@@ -52,8 +50,8 @@ fn print_bits(dev: &Device) {
     println!("Supported events:");
 
     for ev_type in  EventType::EV_SYN.iter() {
-		if dev.has(&ev_type) {
-			println!("  Event type: {} ", ev_type);
+        if dev.has(&ev_type) {
+            println!("  Event type: {} ", ev_type);
         }
 
         match ev_type {
@@ -66,16 +64,16 @@ fn print_bits(dev: &Device) {
             EventType::EV_LED => print_code_bits(dev, &EventCode::EV_LED(EV_LED::LED_NUML),
                                                  &EventCode::EV_LED(EV_LED::LED_MAX)),
             _ => (),
-		}
-	}
+        }
+    }
 }
 
 fn print_props(dev: &Device) {
-	println!("Properties:");
+    println!("Properties:");
 
-	for input_prop in InputProp::INPUT_PROP_POINTER.iter() {
-		if dev.has(&input_prop) {
-			println!("  Property type: {}", input_prop);
+    for input_prop in InputProp::INPUT_PROP_POINTER.iter() {
+        if dev.has(&input_prop) {
+            println!("  Property type: {}", input_prop);
         }
     }
 }
@@ -83,25 +81,25 @@ fn print_props(dev: &Device) {
 fn print_event(ev: &InputEvent) {
     match ev.event_type {
         EventType::EV_SYN => {
-		    println!("Event: time {}.{}, ++++++++++++++++++++ {} +++++++++++++++",
-				     ev.time.tv_sec,
-				     ev.time.tv_usec,
-				     ev.event_type);
+            println!("Event: time {}.{}, ++++++++++++++++++++ {} +++++++++++++++",
+                     ev.time.tv_sec,
+                     ev.time.tv_usec,
+                     ev.event_type);
         }
-	    _ =>  {
-		    println!("Event: time {}.{}, type {} , code {} , value {}",
-			         ev.time.tv_sec,
-			         ev.time.tv_usec,
-			         ev.event_type,
-			         ev.event_code,
-			         ev.value);
+        _ =>  {
+            println!("Event: time {}.{}, type {} , code {} , value {}",
+                     ev.time.tv_sec,
+                     ev.time.tv_usec,
+                     ev.event_type,
+                     ev.event_code,
+                     ev.value);
         }
     }
 }
 
 fn print_sync_dropped_event(ev: &InputEvent) {
-	print!("SYNC DROPPED: ");
-	print_event(ev);
+    print!("SYNC DROPPED: ");
+    print_event(ev);
 }
 
 fn main() {
@@ -119,9 +117,9 @@ fn main() {
     d.set_fd(f).unwrap();
 
     println!("Input device ID: bus 0x{:x} vendor 0x{:x} product 0x{:x}",
-			d.bustype(),
-			d.vendor_id(),
-			d.product_id());
+            d.bustype(),
+            d.vendor_id(),
+            d.product_id());
     println!("Evdev version: {:x}", d.driver_version());
     println!("Input device name: \"{}\"", d.name().unwrap_or(""));
     println!("Phys location: {}", d.phys().unwrap_or(""));
@@ -132,7 +130,7 @@ fn main() {
 
     let mut a: io::Result<(ReadStatus, InputEvent)>;
     loop {
-        a = d.next_event(evdev::ReadFlag::NORMAL | evdev::ReadFlag::BLOCKING);
+        a = d.next_event(ReadFlag::NORMAL | ReadFlag::BLOCKING);
         if a.is_ok() {
             let mut result = a.ok().unwrap();
             match result.0 {
@@ -140,7 +138,7 @@ fn main() {
                     println!("::::::::::::::::::::: dropped ::::::::::::::::::::::");
                     while result.0 == ReadStatus::Sync {
                         print_sync_dropped_event(&result.1);
-                        a = d.next_event(evdev::ReadFlag::SYNC);
+                        a = d.next_event(ReadFlag::SYNC);
                         if a.is_ok() {
                             result = a.ok().unwrap();
                         } else {

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,4 +1,4 @@
-use {TimeVal, ReadStatus, InputEvent, LedState, ReadFlag, GrabMode, AbsInfo};
+use crate::{TimeVal, ReadStatus, InputEvent, LedState, ReadFlag, GrabMode, AbsInfo};
 use libc::{c_int, c_uint, c_void};
 use std::any::Any;
 use std::ffi::CString;
@@ -7,8 +7,8 @@ use std::io;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::ptr;
 
-use enums::*;
-use util::*;
+use crate::enums::*;
+use crate::util::*;
 
 /// Opaque struct representing an evdev device
 pub struct Device {
@@ -50,7 +50,7 @@ impl Device {
     /// device.set_fd(fd);
     /// ```
     pub fn new_from_fd(file: File) -> io::Result<Device> {
-        let mut libevdev = 0 as *mut _;
+        let mut libevdev = std::ptr::null_mut();
         let result = unsafe {
             raw::libevdev_new_from_fd(file.as_raw_fd(), &mut libevdev)
         };
@@ -242,7 +242,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn has_property(&self, prop: &InputProp) -> bool {
         unsafe {
-            raw::libevdev_has_property(self.raw, prop.clone() as c_uint) != 0
+            raw::libevdev_has_property(self.raw, *prop as c_uint) != 0
         }
     }
 
@@ -252,7 +252,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn enable_property(&self, prop: &InputProp) -> io::Result<()> {
         let result = unsafe {
-            raw::libevdev_enable_property(self.raw, prop.clone() as c_uint) as i32
+            raw::libevdev_enable_property(self.raw, *prop as c_uint) as i32
         };
 
         match result {
@@ -266,7 +266,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn has_event_type(&self, ev_type: &EventType) -> bool {
         unsafe {
-            raw::libevdev_has_event_type(self.raw, ev_type.clone() as c_uint) != 0
+            raw::libevdev_has_event_type(self.raw, *ev_type as c_uint) != 0
         }
     }
 
@@ -476,7 +476,7 @@ impl Device {
     pub fn enable_event_type(&self, ev_type: &EventType) -> io::Result<()> {
          let result = unsafe {
             raw::libevdev_enable_event_type(self.raw,
-                                            ev_type.clone() as c_uint)
+                                            *ev_type as c_uint)
         };
 
         match result {
@@ -565,7 +565,7 @@ impl Device {
     pub fn disable_event_type(&self, ev_type: &EventType) -> io::Result<()> {
          let result = unsafe {
             raw::libevdev_disable_event_type(self.raw,
-                                             ev_type.clone() as c_uint)
+                                             *ev_type as c_uint)
         };
 
         match result {

--- a/src/device.rs
+++ b/src/device.rs
@@ -61,9 +61,12 @@ impl Device {
         }
     }
 
-    string_getter!(name, libevdev_get_name,
-                   phys, libevdev_get_phys,
-                   uniq, libevdev_get_uniq);
+    string_getter!(
+        #[doc = "Get device's name, as set by the kernel, or overridden by a call to `set_name`"], name, libevdev_get_name,
+        #[doc = "Get device's physical location, as set by the kernel, or overridden by a call to `set_phys`"], phys, libevdev_get_phys,
+        #[doc = "Get device's unique identifier, as set by the kernel, or overridden by a call to `set_uniq`"], uniq, libevdev_get_uniq
+    );
+    
     string_setter!(set_name, libevdev_set_name,
                    set_phys, libevdev_set_phys,
                    set_uniq, libevdev_set_uniq);

--- a/src/device.rs
+++ b/src/device.rs
@@ -14,7 +14,7 @@ use crate::util::*;
 pub struct Device {
     // The file descriptor of the device must live as long as the device itself.
     _file: Option<File>,
-    pub(crate) raw: *mut raw::libevdev,
+    pub(crate) raw: *mut evdev_sys::libevdev,
 }
 
 impl Device {
@@ -24,7 +24,7 @@ impl Device {
     /// To actually hook up the device to a kernel device, use `set_fd`.
     pub fn new() -> Option<Device> {
         let libevdev = unsafe {
-            raw::libevdev_new()
+            evdev_sys::libevdev_new()
         };
 
         if libevdev.is_null() {
@@ -52,7 +52,7 @@ impl Device {
     pub fn new_from_fd(file: File) -> io::Result<Device> {
         let mut libevdev = std::ptr::null_mut();
         let result = unsafe {
-            raw::libevdev_new_from_fd(file.as_raw_fd(), &mut libevdev)
+            evdev_sys::libevdev_new_from_fd(file.as_raw_fd(), &mut libevdev)
         };
 
         match result {
@@ -76,7 +76,7 @@ impl Device {
     /// if the `set_fd` hasn't been called yet then it return `None`
     pub fn fd(&self) -> Option<File> {
         let result = unsafe {
-            raw::libevdev_get_fd(self.raw)
+            evdev_sys::libevdev_get_fd(self.raw)
         };
 
         if result == 0 {
@@ -99,7 +99,7 @@ impl Device {
     /// a successfull call to `set_fd`.
     pub fn set_fd(&mut self, file: File) -> io::Result<()> {
         let result = unsafe {
-            raw::libevdev_set_fd(self.raw, file.as_raw_fd())
+            evdev_sys::libevdev_set_fd(self.raw, file.as_raw_fd())
         };
 
         match result {
@@ -135,7 +135,7 @@ impl Device {
     /// It is an error to call this function before calling set_fd().
     pub fn change_fd(&mut self, file: File) -> io::Result<()>  {
         let result = unsafe {
-            raw::libevdev_change_fd(self.raw, file.as_raw_fd())
+            evdev_sys::libevdev_change_fd(self.raw, file.as_raw_fd())
         };
 
         match result {
@@ -159,7 +159,7 @@ impl Device {
     /// also re-issue a grab with libevdev_grab().
     pub fn grab(&mut self, grab: GrabMode) -> io::Result<()> {
         let result = unsafe {
-            raw::libevdev_grab(self.raw, grab as c_int)
+            evdev_sys::libevdev_grab(self.raw, grab as c_int)
         };
 
         match result {
@@ -175,7 +175,7 @@ impl Device {
     pub fn abs_info(&self, code: &EventCode) -> Option<AbsInfo> {
         let (_, ev_code) = event_code_to_int(code);
         let a = unsafe {
-            raw::libevdev_get_abs_info(self.raw, ev_code)
+            evdev_sys::libevdev_get_abs_info(self.raw, ev_code)
         };
 
         if a.is_null() {
@@ -203,7 +203,7 @@ impl Device {
         let (_, ev_code) = event_code_to_int(code);
 
         unsafe {
-            raw::libevdev_set_abs_info(self.raw, ev_code,
+            evdev_sys::libevdev_set_abs_info(self.raw, ev_code,
                                        &absinfo.as_raw() as *const _);
         }
     }
@@ -245,7 +245,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn has_property(&self, prop: &InputProp) -> bool {
         unsafe {
-            raw::libevdev_has_property(self.raw, *prop as c_uint) != 0
+            evdev_sys::libevdev_has_property(self.raw, *prop as c_uint) != 0
         }
     }
 
@@ -255,7 +255,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn enable_property(&self, prop: &InputProp) -> io::Result<()> {
         let result = unsafe {
-            raw::libevdev_enable_property(self.raw, *prop as c_uint) as i32
+            evdev_sys::libevdev_enable_property(self.raw, *prop as c_uint) as i32
         };
 
         match result {
@@ -269,7 +269,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn has_event_type(&self, ev_type: &EventType) -> bool {
         unsafe {
-            raw::libevdev_has_event_type(self.raw, *ev_type as c_uint) != 0
+            evdev_sys::libevdev_has_event_type(self.raw, *ev_type as c_uint) != 0
         }
     }
 
@@ -280,7 +280,7 @@ impl Device {
     pub fn has_event_code(&self, code: &EventCode) -> bool {
         unsafe {
             let (ev_type, ev_code) = event_code_to_int(code);
-            raw::libevdev_has_event_code(self.raw,
+            evdev_sys::libevdev_has_event_code(self.raw,
                                          ev_type,
                                          ev_code) != 0
         }
@@ -294,7 +294,7 @@ impl Device {
         let mut value: i32 = 0;
         let (ev_type, ev_code) = event_code_to_int(code);
         let valid = unsafe {
-            raw::libevdev_fetch_event_value(self.raw,
+            evdev_sys::libevdev_fetch_event_value(self.raw,
                                             ev_type,
                                             ev_code ,
                                             &mut value)
@@ -326,7 +326,7 @@ impl Device {
                            -> io::Result<()> {
             let (ev_type, ev_code) = event_code_to_int(code);
             let result = unsafe {
-                raw::libevdev_set_event_value(self.raw,
+                evdev_sys::libevdev_set_event_value(self.raw,
                                               ev_type,
                                               ev_code,
                                               val as c_int)
@@ -353,7 +353,7 @@ impl Device {
     /// you're using select(2) or poll(2).
     pub fn has_event_pending(&self) -> bool {
         unsafe {
-            raw::libevdev_has_event_pending(self.raw) > 0
+            evdev_sys::libevdev_has_event_pending(self.raw) > 0
         }
     }
 
@@ -370,7 +370,7 @@ impl Device {
     /// Return the driver version of a device already intialize with `set_fd`
     pub fn driver_version(&self) -> i32 {
         unsafe {
-            raw::libevdev_get_driver_version(self.raw) as i32
+            evdev_sys::libevdev_get_driver_version(self.raw) as i32
         }
     }
 
@@ -395,7 +395,7 @@ impl Device {
         let (_, ev_code) = event_code_to_int(code);
         let mut value: i32 = 0;
         let valid = unsafe {
-            raw::libevdev_fetch_slot_value(self.raw,
+            evdev_sys::libevdev_fetch_slot_value(self.raw,
                                            slot as c_uint,
                                            ev_code,
                                            &mut value)
@@ -419,7 +419,7 @@ impl Device {
                           -> io::Result<()> {
         let (_, ev_code) = event_code_to_int(code);
         let result = unsafe {
-            raw::libevdev_set_slot_value(self.raw,
+            evdev_sys::libevdev_set_slot_value(self.raw,
                                          slot as c_uint,
                                          ev_code,
                                          val as c_int)
@@ -440,7 +440,7 @@ impl Device {
     /// the return value of `None` for "device does not provide slots at all"
     pub fn num_slots(&self) -> Option<i32> {
         let result = unsafe {
-            raw::libevdev_get_num_slots(self.raw)
+            evdev_sys::libevdev_get_num_slots(self.raw)
         };
 
         match result  {
@@ -458,7 +458,7 @@ impl Device {
     /// process events manually one-by-one.
     pub fn current_slot(&self) -> Option<i32> {
         let result = unsafe {
-            raw::libevdev_get_current_slot(self.raw)
+            evdev_sys::libevdev_get_current_slot(self.raw)
         };
 
         match result {
@@ -478,7 +478,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn enable_event_type(&self, ev_type: &EventType) -> io::Result<()> {
          let result = unsafe {
-            raw::libevdev_enable_event_type(self.raw,
+            evdev_sys::libevdev_enable_event_type(self.raw,
                                             *ev_type as c_uint)
         };
 
@@ -514,7 +514,7 @@ impl Device {
             .unwrap_or_else(|| ptr::null() as *const _ as *const c_void);
 
         let result = unsafe {
-            raw::libevdev_enable_event_code(self.raw,
+            evdev_sys::libevdev_enable_event_code(self.raw,
                                             ev_type as c_uint,
                                             ev_code as c_uint,
                                             data)
@@ -567,7 +567,7 @@ impl Device {
     /// available for the sake of maintaining compatibility with libevdev.
     pub fn disable_event_type(&self, ev_type: &EventType) -> io::Result<()> {
          let result = unsafe {
-            raw::libevdev_disable_event_type(self.raw,
+            evdev_sys::libevdev_disable_event_type(self.raw,
                                              *ev_type as c_uint)
         };
 
@@ -597,7 +597,7 @@ impl Device {
                               -> io::Result<()> {
         let (ev_type, ev_code) = event_code_to_int(code);
         let result = unsafe {
-            raw::libevdev_disable_event_code(self.raw,
+            evdev_sys::libevdev_disable_event_code(self.raw,
                                             ev_type,
                                             ev_code)
         };
@@ -614,7 +614,7 @@ impl Device {
         let (_, ev_code) = event_code_to_int(code);
 
         unsafe {
-            raw::libevdev_kernel_set_abs_info(self.raw, ev_code,
+            evdev_sys::libevdev_kernel_set_abs_info(self.raw, ev_code,
                                               &absinfo.as_raw() as *const _);
         }
     }
@@ -626,7 +626,7 @@ impl Device {
                                  -> io::Result<()> {
         let (_, ev_code) = event_code_to_int(code);
         let result = unsafe {
-            raw::libevdev_kernel_set_led_value(self.raw,
+            evdev_sys::libevdev_kernel_set_led_value(self.raw,
                                                ev_code,
                                                value as c_int)
         };
@@ -644,7 +644,7 @@ impl Device {
     /// this device.
     pub fn set_clock_id(&self, clockid: i32) -> io::Result<()> {
          let result = unsafe {
-            raw::libevdev_set_clock_id(self.raw,
+            evdev_sys::libevdev_set_clock_id(self.raw,
                                        clockid as c_int)
         };
 
@@ -682,8 +682,8 @@ impl Device {
     /// `ReadStatus::Sync`.
     pub fn next_event(&self, flags: ReadFlag)
                       -> io::Result<(ReadStatus, InputEvent)> {
-        let mut ev = raw::input_event {
-            time: raw::timeval {
+        let mut ev = evdev_sys::input_event {
+            time: evdev_sys::timeval {
                 tv_sec: 0,
                 tv_usec: 0,
             },
@@ -693,7 +693,7 @@ impl Device {
         };
 
         let result = unsafe {
-            raw::libevdev_next_event(self.raw, flags.bits as c_uint, &mut ev)
+            evdev_sys::libevdev_next_event(self.raw, flags.bits as c_uint, &mut ev)
         };
 
         let event = InputEvent {
@@ -707,8 +707,8 @@ impl Device {
         };
 
         match result {
-            raw::LIBEVDEV_READ_STATUS_SUCCESS => Ok((ReadStatus::Success, event)),
-            raw::LIBEVDEV_READ_STATUS_SYNC => Ok((ReadStatus::Sync, event)),
+            evdev_sys::LIBEVDEV_READ_STATUS_SUCCESS => Ok((ReadStatus::Success, event)),
+            evdev_sys::LIBEVDEV_READ_STATUS_SYNC => Ok((ReadStatus::Sync, event)),
             error => Err(io::Error::from_raw_os_error(-error)),
         }
     }
@@ -717,7 +717,7 @@ impl Device {
 impl Drop for Device {
     fn drop(&mut self) {
         unsafe {
-            raw::libevdev_free(self.raw);
+            evdev_sys::libevdev_free(self.raw);
         }
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,8 +1,10 @@
 /* THIS FILE IS GENERATED, DO NOT EDIT */
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EventType {
     EV_SYN = 0,
     EV_KEY = 1,
@@ -42,7 +44,7 @@ pub fn int_to_event_type(code: u32) -> Option<EventType> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EventCode {
     EV_SYN(EV_SYN),
     EV_KEY(EV_KEY),
@@ -62,7 +64,7 @@ pub enum EventCode {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_REL {
     REL_X = 0,
     REL_Y = 1,
@@ -102,7 +104,7 @@ pub fn int_to_ev_rel(code: u32) -> Option<EV_REL> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_ABS {
     ABS_X = 0,
     ABS_Y = 1,
@@ -200,7 +202,7 @@ pub fn int_to_ev_abs(code: u32) -> Option<EV_ABS> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_KEY {
     KEY_RESERVED = 0,
     KEY_ESC = 1,
@@ -1306,7 +1308,7 @@ pub fn int_to_ev_key(code: u32) -> Option<EV_KEY> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_LED {
     LED_NUML = 0,
     LED_CAPSL = 1,
@@ -1342,7 +1344,7 @@ pub fn int_to_ev_led(code: u32) -> Option<EV_LED> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SND {
     SND_CLICK = 0,
     SND_BELL = 1,
@@ -1362,7 +1364,7 @@ pub fn int_to_ev_snd(code: u32) -> Option<EV_SND> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_MSC {
     MSC_SERIAL = 0,
     MSC_PULSELED = 1,
@@ -1388,7 +1390,7 @@ pub fn int_to_ev_msc(code: u32) -> Option<EV_MSC> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SW {
     SW_LID = 0,
     SW_TABLET_MODE = 1,
@@ -1436,7 +1438,7 @@ pub fn int_to_ev_sw(code: u32) -> Option<EV_SW> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_SYN {
     SYN_REPORT = 0,
     SYN_CONFIG = 1,
@@ -1458,7 +1460,7 @@ pub fn int_to_ev_syn(code: u32) -> Option<EV_SYN> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_REP {
     REP_DELAY = 0,
     REP_PERIOD = 1,
@@ -1478,7 +1480,7 @@ pub fn int_to_ev_rep(code: u32) -> Option<EV_REP> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum InputProp {
     INPUT_PROP_POINTER = 0,
     INPUT_PROP_DIRECT = 1,
@@ -1506,7 +1508,7 @@ pub fn int_to_input_prop(code: u32) -> Option<InputProp> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum EV_FF {
     FF_STATUS_STOPPED = 0,
     FF_STATUS_PLAYING = 1,
@@ -1560,7 +1562,7 @@ pub fn int_to_ev_ff(code: u32) -> Option<EV_FF> {
 
 #[allow(non_camel_case_types)]
 #[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BusType {
     BUS_PCI = 1,
     BUS_ISAPNP = 2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ use bitflags::bitflags;
 use enums::*;
 use util::*;
 
+use evdev_sys as raw;
+
 #[doc(inline)]
 pub use device::Device;
 #[doc(inline)]
@@ -74,9 +76,9 @@ use serde::{Serialize, Deserialize};
 
 pub enum GrabMode {
     /// Grab the device if not currently grabbed
-    Grab = evdev_sys::LIBEVDEV_GRAB as isize,
+    Grab = raw::LIBEVDEV_GRAB as isize,
     /// Ungrab the device if currently grabbed
-    Ungrab = evdev_sys::LIBEVDEV_UNGRAB as isize,
+    Ungrab = raw::LIBEVDEV_UNGRAB as isize,
 }
 
 bitflags! {
@@ -97,18 +99,18 @@ bitflags! {
 pub enum ReadStatus {
     /// `next_event` has finished without an error and an event is available
     /// for processing.
-    Success = evdev_sys::LIBEVDEV_READ_STATUS_SUCCESS as isize,
+    Success = raw::LIBEVDEV_READ_STATUS_SUCCESS as isize,
     /// Depending on the `next_event` read flag:
     /// libevdev received a SYN_DROPPED from the device, and the caller should
     /// now resync the device, or, an event has been read in sync mode.
-    Sync = evdev_sys::LIBEVDEV_READ_STATUS_SYNC as isize,
+    Sync = raw::LIBEVDEV_READ_STATUS_SYNC as isize,
 }
 
 pub enum LedState {
     /// Turn the LED on
-    On = evdev_sys::LIBEVDEV_LED_ON as isize,
+    On = raw::LIBEVDEV_LED_ON as isize,
     /// Turn the LED off
-    Off = evdev_sys::LIBEVDEV_LED_OFF as isize,
+    Off = raw::LIBEVDEV_LED_OFF as isize,
 }
 
 pub struct DeviceId {
@@ -245,7 +247,7 @@ impl InputEvent {
 
     pub fn is_type(&self, ev_type: &EventType) -> bool {
         unsafe {
-            evdev_sys::libevdev_event_is_type(&self.as_raw(), *ev_type as c_uint) == 1
+            raw::libevdev_event_is_type(&self.as_raw(), *ev_type as c_uint) == 1
         }
     }
 
@@ -253,7 +255,7 @@ impl InputEvent {
         let (ev_type, ev_code) = event_code_to_int(code);
 
         unsafe {
-            evdev_sys::libevdev_event_is_code(&self.as_raw(), ev_type, ev_code) == 1
+            raw::libevdev_event_is_code(&self.as_raw(), ev_type, ev_code) == 1
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,6 @@
 //! evdev-rs = { version = "0.4.0", features = ["serde"] }
 //! ```
 
-extern crate evdev_sys as raw;
-
 #[macro_use]
 mod macros;
 pub mod device;
@@ -76,9 +74,9 @@ use serde::{Serialize, Deserialize};
 
 pub enum GrabMode {
     /// Grab the device if not currently grabbed
-    Grab = raw::LIBEVDEV_GRAB as isize,
+    Grab = evdev_sys::LIBEVDEV_GRAB as isize,
     /// Ungrab the device if currently grabbed
-    Ungrab = raw::LIBEVDEV_UNGRAB as isize,
+    Ungrab = evdev_sys::LIBEVDEV_UNGRAB as isize,
 }
 
 bitflags! {
@@ -99,18 +97,18 @@ bitflags! {
 pub enum ReadStatus {
     /// `next_event` has finished without an error and an event is available
     /// for processing.
-    Success = raw::LIBEVDEV_READ_STATUS_SUCCESS as isize,
+    Success = evdev_sys::LIBEVDEV_READ_STATUS_SUCCESS as isize,
     /// Depending on the `next_event` read flag:
     /// libevdev received a SYN_DROPPED from the device, and the caller should
     /// now resync the device, or, an event has been read in sync mode.
-    Sync = raw::LIBEVDEV_READ_STATUS_SYNC as isize,
+    Sync = evdev_sys::LIBEVDEV_READ_STATUS_SYNC as isize,
 }
 
 pub enum LedState {
     /// Turn the LED on
-    On = raw::LIBEVDEV_LED_ON as isize,
+    On = evdev_sys::LIBEVDEV_LED_ON as isize,
     /// Turn the LED off
-    Off = raw::LIBEVDEV_LED_OFF as isize,
+    Off = evdev_sys::LIBEVDEV_LED_OFF as isize,
 }
 
 pub struct DeviceId {
@@ -247,7 +245,7 @@ impl InputEvent {
 
     pub fn is_type(&self, ev_type: &EventType) -> bool {
         unsafe {
-            raw::libevdev_event_is_type(&self.as_raw(), *ev_type as c_uint) == 1
+            evdev_sys::libevdev_event_is_type(&self.as_raw(), *ev_type as c_uint) == 1
         }
     }
 
@@ -255,7 +253,7 @@ impl InputEvent {
         let (ev_type, ev_code) = event_code_to_int(code);
 
         unsafe {
-            raw::libevdev_event_is_code(&self.as_raw(), ev_type, ev_code) == 1
+            evdev_sys::libevdev_event_is_code(&self.as_raw(), ev_type, ev_code) == 1
         }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,10 @@
 pub enum LogPriority {
     /// critical errors and application bugs
-    Error = raw::LIBEVDEV_LOG_ERROR as isize,
+    Error = evdev_sys::LIBEVDEV_LOG_ERROR as isize,
     /// informational messages
-    Info = raw::LIBEVDEV_LOG_INFO as isize,
+    Info = evdev_sys::LIBEVDEV_LOG_INFO as isize,
     /// debug information
-    Debug = raw::LIBEVDEV_LOG_DEBUG as isize,
+    Debug = evdev_sys::LIBEVDEV_LOG_DEBUG as isize,
 }
 
 
@@ -13,7 +13,7 @@ pub enum LogPriority {
 /// is a global setting and applies to any future logging messages.
 pub fn set_log_priority(priority: LogPriority) {
     unsafe {
-        raw::libevdev_set_log_priority(priority as i32);
+        evdev_sys::libevdev_set_log_priority(priority as i32);
     }
 }
 
@@ -21,11 +21,11 @@ pub fn set_log_priority(priority: LogPriority) {
 /// are printed, others are discarded. This is a global setting.
 pub fn get_log_priority() -> LogPriority {
     unsafe {
-        let priority = raw::libevdev_get_log_priority();
+        let priority = evdev_sys::libevdev_get_log_priority();
         match priority {
-            raw::LIBEVDEV_LOG_ERROR => LogPriority::Error,
-            raw::LIBEVDEV_LOG_INFO => LogPriority::Info,
-            raw::LIBEVDEV_LOG_DEBUG => LogPriority::Debug,
+            evdev_sys::LIBEVDEV_LOG_ERROR => LogPriority::Error,
+            evdev_sys::LIBEVDEV_LOG_INFO => LogPriority::Info,
+            evdev_sys::LIBEVDEV_LOG_DEBUG => LogPriority::Debug,
             c => panic!("unknown log priority: {}", c),
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,12 @@
+use evdev_sys as raw;
+
 pub enum LogPriority {
     /// critical errors and application bugs
-    Error = evdev_sys::LIBEVDEV_LOG_ERROR as isize,
+    Error = raw::LIBEVDEV_LOG_ERROR as isize,
     /// informational messages
-    Info = evdev_sys::LIBEVDEV_LOG_INFO as isize,
+    Info = raw::LIBEVDEV_LOG_INFO as isize,
     /// debug information
-    Debug = evdev_sys::LIBEVDEV_LOG_DEBUG as isize,
+    Debug = raw::LIBEVDEV_LOG_DEBUG as isize,
 }
 
 
@@ -13,7 +15,7 @@ pub enum LogPriority {
 /// is a global setting and applies to any future logging messages.
 pub fn set_log_priority(priority: LogPriority) {
     unsafe {
-        evdev_sys::libevdev_set_log_priority(priority as i32);
+        raw::libevdev_set_log_priority(priority as i32);
     }
 }
 
@@ -21,11 +23,11 @@ pub fn set_log_priority(priority: LogPriority) {
 /// are printed, others are discarded. This is a global setting.
 pub fn get_log_priority() -> LogPriority {
     unsafe {
-        let priority = evdev_sys::libevdev_get_log_priority();
+        let priority = raw::libevdev_get_log_priority();
         match priority {
-            evdev_sys::LIBEVDEV_LOG_ERROR => LogPriority::Error,
-            evdev_sys::LIBEVDEV_LOG_INFO => LogPriority::Info,
-            evdev_sys::LIBEVDEV_LOG_DEBUG => LogPriority::Debug,
+            raw::LIBEVDEV_LOG_ERROR => LogPriority::Error,
+            raw::LIBEVDEV_LOG_INFO => LogPriority::Info,
+            raw::LIBEVDEV_LOG_DEBUG => LogPriority::Debug,
             c => panic!("unknown log priority: {}", c),
         }
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,3 @@
-use raw;
-
 pub enum LogPriority {
     /// critical errors and application bugs
     Error = raw::LIBEVDEV_LOG_ERROR as isize,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! string_getter {
             #[$doc]
             pub fn $func_name (&self) -> Option<&str> {
                 unsafe {
-                    ptr_to_str(raw::$c_func(self.raw))
+                    ptr_to_str(evdev_sys::$c_func(self.raw))
                 }
             }
         )*
@@ -17,7 +17,7 @@ macro_rules! string_setter {
             pub fn $func_name (&self, field: &str) {
                 let field = CString::new(field).unwrap();
                 unsafe {
-                    raw::$c_func(self.raw, field.as_ptr())
+                    evdev_sys::$c_func(self.raw, field.as_ptr())
                 }
             }
         )*
@@ -29,7 +29,7 @@ macro_rules! product_getter {
         $(
             pub fn $func_name (&self) -> u16 {
                 unsafe {
-                    raw::$c_func(self.raw) as u16
+                    evdev_sys::$c_func(self.raw) as u16
                 }
             }
         )*
@@ -41,7 +41,7 @@ macro_rules! product_setter {
         $(
             pub fn $func_name (&self, field: u16) {
                 unsafe {
-                    raw::$c_func(self.raw, field as c_int);
+                    evdev_sys::$c_func(self.raw, field as c_int);
                 }
             }
         )*
@@ -54,7 +54,7 @@ macro_rules! abs_getter {
             pub fn $func_name (&self,
                                code: u32) -> std::io::Result<i32> {
                 let result = unsafe {
-                    raw::$c_func(self.raw, code as c_uint) as i32
+                    evdev_sys::$c_func(self.raw, code as c_uint) as i32
                 };
 
                 match result {
@@ -73,7 +73,7 @@ macro_rules! abs_setter {
                                code: u32,
                                val: i32) {
                 unsafe {
-                    raw::$c_func(self.raw, code as c_uint, val as c_int);
+                    evdev_sys::$c_func(self.raw, code as c_uint, val as c_int);
                 }
             }
         )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,9 +2,9 @@ macro_rules! string_getter {
     ( $( $func_name:ident, $c_func: ident ),* ) => {
         $(
             pub fn $func_name (&self) -> Option<&str> {
-                ptr_to_str(unsafe {
-                    raw::$c_func(self.raw)
-                })
+                unsafe {
+                    ptr_to_str(raw::$c_func(self.raw))
+                }
             }
         )*
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,7 @@
 macro_rules! string_getter {
-    ( $( $func_name:ident, $c_func: ident ),* ) => {
+    ( $( #[$doc:meta], $func_name:ident, $c_func: ident ),* ) => {
         $(
+            #[$doc]
             pub fn $func_name (&self) -> Option<&str> {
                 unsafe {
                     ptr_to_str(raw::$c_func(self.raw))

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! string_getter {
             #[$doc]
             pub fn $func_name (&self) -> Option<&str> {
                 unsafe {
-                    ptr_to_str(evdev_sys::$c_func(self.raw))
+                    ptr_to_str(raw::$c_func(self.raw))
                 }
             }
         )*
@@ -17,7 +17,7 @@ macro_rules! string_setter {
             pub fn $func_name (&self, field: &str) {
                 let field = CString::new(field).unwrap();
                 unsafe {
-                    evdev_sys::$c_func(self.raw, field.as_ptr())
+                    raw::$c_func(self.raw, field.as_ptr())
                 }
             }
         )*
@@ -29,7 +29,7 @@ macro_rules! product_getter {
         $(
             pub fn $func_name (&self) -> u16 {
                 unsafe {
-                    evdev_sys::$c_func(self.raw) as u16
+                    raw::$c_func(self.raw) as u16
                 }
             }
         )*
@@ -41,7 +41,7 @@ macro_rules! product_setter {
         $(
             pub fn $func_name (&self, field: u16) {
                 unsafe {
-                    evdev_sys::$c_func(self.raw, field as c_int);
+                    raw::$c_func(self.raw, field as c_int);
                 }
             }
         )*
@@ -54,7 +54,7 @@ macro_rules! abs_getter {
             pub fn $func_name (&self,
                                code: u32) -> std::io::Result<i32> {
                 let result = unsafe {
-                    evdev_sys::$c_func(self.raw, code as c_uint) as i32
+                    raw::$c_func(self.raw, code as c_uint) as i32
                 };
 
                 match result {
@@ -73,7 +73,7 @@ macro_rules! abs_setter {
                                code: u32,
                                val: i32) {
                 unsafe {
-                    evdev_sys::$c_func(self.raw, code as c_uint, val as c_int);
+                    raw::$c_func(self.raw, code as c_uint, val as c_int);
                 }
             }
         )*

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -7,9 +7,11 @@ use std::os::unix::io::FromRawFd;
 
 use crate::util::*;
 
+use evdev_sys as raw;
+
 /// Opaque struct representing an evdev uinput device
 pub struct UInputDevice {
-    raw: *mut evdev_sys::libevdev_uinput
+    raw: *mut raw::libevdev_uinput
 }
 
 impl UInputDevice {
@@ -20,9 +22,9 @@ impl UInputDevice {
     pub fn create_from_device(device: &Device) -> io::Result<UInputDevice> {
         let mut libevdev_uinput = std::ptr::null_mut();
         let result = unsafe {
-            evdev_sys::libevdev_uinput_create_from_device(
+            raw::libevdev_uinput_create_from_device(
                 device.raw,
-                evdev_sys::LIBEVDEV_UINPUT_OPEN_MANAGED,
+                raw::LIBEVDEV_UINPUT_OPEN_MANAGED,
                 &mut libevdev_uinput
             )
         };
@@ -58,7 +60,7 @@ device node returned with libevdev_uinput_get_devnode()."],
     ///  descriptor will destroy the uinput device.
     pub fn fd(&self) -> Option<File> {
         let result = unsafe {
-            evdev_sys::libevdev_uinput_get_fd(self.raw)
+            raw::libevdev_uinput_get_fd(self.raw)
         };
 
         if result == 0 {
@@ -81,7 +83,7 @@ device node returned with libevdev_uinput_get_devnode()."],
         let ev_value = event.value as c_int;
 
         let result = unsafe {
-            evdev_sys::libevdev_uinput_write_event(self.raw, ev_type, ev_code, ev_value)
+            raw::libevdev_uinput_write_event(self.raw, ev_type, ev_code, ev_value)
         };
 
         match result {
@@ -94,7 +96,7 @@ device node returned with libevdev_uinput_get_devnode()."],
 impl Drop for UInputDevice {
     fn drop(&mut self) {
         unsafe {
-            evdev_sys::libevdev_uinput_destroy(self.raw);
+            raw::libevdev_uinput_destroy(self.raw);
         }
     }
 }

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -1,11 +1,11 @@
-use InputEvent;
+use crate::InputEvent;
 use libc::c_int;
-use device::Device;
+use crate::device::Device;
 use std::io;
 use std::fs::File;
 use std::os::unix::io::FromRawFd;
 
-use util::*;
+use crate::util::*;
 
 /// Opaque struct representing an evdev uinput device
 pub struct UInputDevice {
@@ -18,7 +18,7 @@ impl UInputDevice {
     /// The uinput device will be an exact copy of the libevdev device, minus
     /// the bits that uinput doesn't allow to be set.
     pub fn create_from_device(device: &Device) -> io::Result<UInputDevice> {
-        let mut libevdev_uinput = 0 as *mut _;
+        let mut libevdev_uinput = std::ptr::null_mut();
         let result = unsafe {
             raw::libevdev_uinput_create_from_device(device.raw, raw::LIBEVDEV_UINPUT_OPEN_MANAGED, &mut libevdev_uinput)
         };

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -9,7 +9,7 @@ use crate::util::*;
 
 /// Opaque struct representing an evdev uinput device
 pub struct UInputDevice {
-    raw: *mut raw::libevdev_uinput
+    raw: *mut evdev_sys::libevdev_uinput
 }
 
 impl UInputDevice {
@@ -20,7 +20,11 @@ impl UInputDevice {
     pub fn create_from_device(device: &Device) -> io::Result<UInputDevice> {
         let mut libevdev_uinput = std::ptr::null_mut();
         let result = unsafe {
-            raw::libevdev_uinput_create_from_device(device.raw, raw::LIBEVDEV_UINPUT_OPEN_MANAGED, &mut libevdev_uinput)
+            evdev_sys::libevdev_uinput_create_from_device(
+                device.raw,
+                evdev_sys::LIBEVDEV_UINPUT_OPEN_MANAGED,
+                &mut libevdev_uinput
+            )
         };
 
         match result {
@@ -54,7 +58,7 @@ device node returned with libevdev_uinput_get_devnode()."],
     ///  descriptor will destroy the uinput device.
     pub fn fd(&self) -> Option<File> {
         let result = unsafe {
-            raw::libevdev_uinput_get_fd(self.raw)
+            evdev_sys::libevdev_uinput_get_fd(self.raw)
         };
 
         if result == 0 {
@@ -77,7 +81,7 @@ device node returned with libevdev_uinput_get_devnode()."],
         let ev_value = event.value as c_int;
 
         let result = unsafe {
-            raw::libevdev_uinput_write_event(self.raw, ev_type, ev_code, ev_value)
+            evdev_sys::libevdev_uinput_write_event(self.raw, ev_type, ev_code, ev_value)
         };
 
         match result {
@@ -90,7 +94,7 @@ device node returned with libevdev_uinput_get_devnode()."],
 impl Drop for UInputDevice {
     fn drop(&mut self) {
         unsafe {
-            raw::libevdev_uinput_destroy(self.raw);
+            evdev_sys::libevdev_uinput_destroy(self.raw);
         }
     }
 }

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -29,20 +29,23 @@ impl UInputDevice {
         }
     }
 
-    /// Return the device node representing this uinput device.
-    ///
-    /// This relies on libevdev_uinput_get_syspath() to provide a valid syspath.
-    string_getter!(devnode, libevdev_uinput_get_devnode);
+    
+    string_getter!(
+        #[doc = "Return the device node representing this uinput device.
 
-    /// Return the syspath representing this uinput device.
-    ///
-    /// If the UI_GET_SYSNAME ioctl not available, libevdev makes an educated
-    /// guess. The UI_GET_SYSNAME ioctl is available since Linux 3.15.
-    ///
-    /// The syspath returned is the one of the input node itself
-    /// (e.g. /sys/devices/virtual/input/input123), not the syspath of the
-    /// device node returned with libevdev_uinput_get_devnode().
-    string_getter!(syspath, libevdev_uinput_get_syspath);
+This relies on `libevdev_uinput_get_syspath()` to provide a valid syspath."],
+        devnode, libevdev_uinput_get_devnode
+    );
+
+    string_getter!(#[doc = "Return the syspath representing this uinput device.
+
+If the UI_GET_SYSNAME ioctl not available, libevdev makes an educated
+guess. The UI_GET_SYSNAME ioctl is available since Linux 3.15.
+
+The syspath returned is the one of the input node itself
+(e.g. /sys/devices/virtual/input/input123), not the syspath of the
+device node returned with libevdev_uinput_get_devnode()."],
+        syspath, libevdev_uinput_get_syspath);
 
     /// Return the file descriptor used to create this uinput device.
     ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -108,7 +108,7 @@ pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", unsafe { ptr_to_str(
-            raw::libevdev_event_type_get_name(*self as c_uint)
+            evdev_sys::libevdev_event_type_get_name(*self as c_uint)
         )}.unwrap_or(""))
     }
 }
@@ -117,7 +117,7 @@ impl fmt::Display for EventCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (ev_type, ev_code) = event_code_to_int(self);
         write!(f, "{}", unsafe { ptr_to_str(
-            raw::libevdev_event_code_get_name(ev_type, ev_code)
+            evdev_sys::libevdev_event_code_get_name(ev_type, ev_code)
         )}.unwrap_or(""))
     }
 }
@@ -125,7 +125,7 @@ impl fmt::Display for EventCode {
 impl fmt::Display for InputProp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", unsafe { ptr_to_str(
-            raw::libevdev_property_get_name(*self as c_uint)
+            evdev_sys::libevdev_property_get_name(*self as c_uint)
         )}.unwrap_or(""))
     }
 }
@@ -139,7 +139,7 @@ impl EventType {
     pub fn from_str(name: &str) -> Option<EventType> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            raw::libevdev_event_type_from_name(name.as_ptr())
+            evdev_sys::libevdev_event_type_from_name(name.as_ptr())
         };
 
         match result {
@@ -152,7 +152,7 @@ impl EventType {
     /// of EV_ABS, or Errno for an invalid type.
     pub fn get_max(ev_type: &EventType) -> Option<i32> {
         let result = unsafe {
-            raw::libevdev_event_type_get_max(*ev_type as c_uint)
+            evdev_sys::libevdev_event_type_get_max(*ev_type as c_uint)
         };
 
         match result {
@@ -174,7 +174,7 @@ impl EventCode {
     pub fn from_str(ev_type: &EventType, name: &str) -> Option<EventCode> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            raw::libevdev_event_code_from_name(*ev_type as c_uint, name.as_ptr())
+            evdev_sys::libevdev_event_code_from_name(*ev_type as c_uint, name.as_ptr())
         };
 
         match result {
@@ -196,7 +196,7 @@ impl InputProp {
     pub fn from_str(name: &str) -> Option<InputProp> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            raw::libevdev_property_from_name(name.as_ptr())
+            evdev_sys::libevdev_property_from_name(name.as_ptr())
         };
 
         match result {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,24 +1,16 @@
-use enums::*;
+use crate::enums::*;
 use libc::{c_char, c_uint};
-use raw;
+use log::warn;
 use std::fmt;
 use std::ffi::{CStr, CString};
 
-pub(crate) fn ptr_to_str(ptr: *const c_char) -> Option<&'static str> {
-    let slice : Option<&CStr> = unsafe {
-        if ptr.is_null() {
-            return None
-        }
-        Some(CStr::from_ptr(ptr))
-    };
-
-    match slice {
-        None => None,
-        Some(s) => {
-            let buf : &[u8] = s.to_bytes();
-            Some(std::str::from_utf8(buf).unwrap())
-        }
+pub(crate) unsafe fn ptr_to_str(ptr: *const c_char) -> Option<&'static str> {
+    if ptr.is_null() {
+        return None;
     }
+    let slice: &CStr = CStr::from_ptr(ptr);
+    let buf: &[u8] = slice.to_bytes();
+    std::str::from_utf8(buf).ok()
 }
 
 pub struct EventTypeIterator {
@@ -34,64 +26,26 @@ pub struct InputPropIterator {
 }
 
 pub fn event_code_to_int(event_code: &EventCode) -> (c_uint, c_uint) {
-    let mut ev_type: c_uint = 0;
-    let mut ev_code: c_uint = 0;
-    match event_code.clone() {
-        EventCode::EV_SYN(code) => {
-            ev_type = EventType::EV_SYN as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_KEY(code) => {
-            ev_type = EventType::EV_KEY as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_REL(code) => {
-            ev_type = EventType::EV_REL as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_ABS(code) => {
-            ev_type = EventType::EV_ABS as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_MSC(code) => {
-            ev_type = EventType::EV_MSC as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_SW(code) => {
-            ev_type = EventType::EV_SW as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_LED(code) => {
-            ev_type = EventType::EV_LED as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_SND(code) => {
-            ev_type = EventType::EV_SND as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_REP(code) => {
-            ev_type = EventType::EV_REP as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_FF(code) => {
-            ev_type = EventType::EV_FF as c_uint;
-            ev_code = code as c_uint;
-        },
-        EventCode::EV_FF_STATUS(code) => {
-            ev_type = EventType::EV_FF_STATUS as c_uint;
-            ev_code = code as c_uint;
-        },
+    match *event_code {
+        EventCode::EV_SYN(code) => (EventType::EV_SYN as c_uint, code as c_uint),
+        EventCode::EV_KEY(code) => (EventType::EV_KEY as c_uint, code as c_uint),
+        EventCode::EV_REL(code) => (EventType::EV_REL as c_uint, code as c_uint),
+        EventCode::EV_ABS(code) => (EventType::EV_ABS as c_uint, code as c_uint),
+        EventCode::EV_MSC(code) => (EventType::EV_MSC as c_uint, code as c_uint),
+        EventCode::EV_SW(code) => (EventType::EV_SW as c_uint, code as c_uint),
+        EventCode::EV_LED(code) => (EventType::EV_LED as c_uint, code as c_uint),
+        EventCode::EV_SND(code) => (EventType::EV_SND as c_uint, code as c_uint),
+        EventCode::EV_REP(code) => (EventType::EV_REP as c_uint, code as c_uint),
+        EventCode::EV_FF(code) => (EventType::EV_FF as c_uint, code as c_uint),
+        EventCode::EV_FF_STATUS(code) => (EventType::EV_FF_STATUS as c_uint, code as c_uint),
         EventCode::EV_UNK { event_type, event_code } => {
-            ev_type = event_type as c_uint;
-            ev_code = event_code as c_uint;
-        },
+            (event_type as c_uint, event_code as c_uint)
+        }
         _ => {
             warn!("Event code not found");
+            (0, 0)
         }
     }
-
-    (ev_type, ev_code)
-
 }
 
 pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
@@ -148,43 +102,37 @@ pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
         EventType::EV_MAX =>    Some(EventCode::EV_MAX),
     };
 
-    match ev_code {
-        Some(c) => c,
-        None => EventCode::EV_UNK {
-            event_type: event_type as u32,
-            event_code: event_code as u32,
-        },
-    }
+    ev_code.unwrap_or(EventCode::EV_UNK {event_type, event_code})
 }
 
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ptr_to_str(unsafe {
-            raw::libevdev_event_type_get_name(self.clone() as c_uint)
-        }).unwrap_or(""))
+        write!(f, "{}", unsafe { ptr_to_str(
+            raw::libevdev_event_type_get_name(*self as c_uint)
+        )}.unwrap_or(""))
     }
 }
 
 impl fmt::Display for EventCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (ev_type, ev_code) = event_code_to_int(self);
-        write!(f, "{}", ptr_to_str(unsafe {
+        write!(f, "{}", unsafe { ptr_to_str(
             raw::libevdev_event_code_get_name(ev_type, ev_code)
-        }).unwrap_or(""))
+        )}.unwrap_or(""))
     }
 }
 
 impl fmt::Display for InputProp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", ptr_to_str(unsafe {
-            raw::libevdev_property_get_name(self.clone() as c_uint)
-        }).unwrap_or(""))
+        write!(f, "{}", unsafe { ptr_to_str(
+            raw::libevdev_property_get_name(*self as c_uint)
+        )}.unwrap_or(""))
     }
 }
 
 impl EventType {
     pub fn iter(&self) -> EventTypeIterator {
-        EventTypeIterator { current: self.clone() }
+        EventTypeIterator { current: *self }
     }
 
     /// The given type constant for the passed name or Errno if not found.
@@ -204,7 +152,7 @@ impl EventType {
     /// of EV_ABS, or Errno for an invalid type.
     pub fn get_max(ev_type: &EventType) -> Option<i32> {
         let result = unsafe {
-            raw::libevdev_event_type_get_max(ev_type.clone() as c_uint)
+            raw::libevdev_event_type_get_max(*ev_type as c_uint)
         };
 
         match result {
@@ -216,7 +164,7 @@ impl EventType {
 
 impl EventCode {
     pub fn iter(&self) -> EventCodeIterator {
-        EventCodeIterator { current: self.clone() }
+        EventCodeIterator { current: *self }
     }
 
     /// Look up an event code by its type and name. Event codes start with a fixed
@@ -226,19 +174,19 @@ impl EventCode {
     pub fn from_str(ev_type: &EventType, name: &str) -> Option<EventCode> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            raw::libevdev_event_code_from_name(ev_type.clone() as c_uint, name.as_ptr())
+            raw::libevdev_event_code_from_name(*ev_type as c_uint, name.as_ptr())
         };
 
         match result {
             -1 => None,
-             k => Some(int_to_event_code(ev_type.clone() as u32, k as u32)),
+             k => Some(int_to_event_code(*ev_type as u32, k as u32)),
         }
     }
 }
 
 impl InputProp {
     pub fn iter(&self) -> InputPropIterator {
-        InputPropIterator { current: self.clone() }
+        InputPropIterator { current: *self }
     }
 
     /// Look up an input property by its name. Properties start with the fixed
@@ -264,17 +212,15 @@ impl Iterator for EventTypeIterator {
 
     fn next(&mut self) -> Option<EventType> {
         match self.current {
-            EventType::EV_MAX => {
-                return None;
-            }
+            EventType::EV_MAX => None,
             _ => {
-                let mut raw_code = (self.current.clone() as u32) + 1;
+                let mut raw_code = (self.current as u32) + 1;
                 loop {
                     match int_to_event_type(raw_code) {
                         // TODO: Find a way to iterate over Unknown types
                         Some(EventType::EV_UNK) => raw_code += 1,
                         Some(x) => {
-                            let code = self.current.clone();
+                            let code = self.current;
                             self.current = x;
                             return Some(code);
                         }
@@ -290,225 +236,203 @@ impl Iterator for EventCodeIterator {
     type Item = EventCode;
 
     fn next(&mut self) -> Option<EventCode> {
-        match self.current.clone() {
-            EventCode::EV_SYN(code) => {
-                match code {
-                    EV_SYN::SYN_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_KEY(EV_KEY::KEY_RESERVED);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_syn(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_SYN(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+        match self.current {
+            EventCode::EV_SYN(code) => match code {
+                EV_SYN::SYN_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_KEY(EV_KEY::KEY_RESERVED);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_syn(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_SYN(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_KEY(code) => {
-                match code {
-                    EV_KEY::KEY_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_REL(EV_REL::REL_X);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_key(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_KEY(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_KEY(code) => match code {
+                EV_KEY::KEY_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_REL(EV_REL::REL_X);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_key(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_KEY(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_REL(code) => {
-                match code {
-                    EV_REL::REL_MAX=> {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_ABS(EV_ABS::ABS_X);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_rel(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_REL(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_REL(code) => match code {
+                EV_REL::REL_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_ABS(EV_ABS::ABS_X);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_rel(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_REL(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_ABS(code) => {
-                match code {
-                    EV_ABS::ABS_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_MSC(EV_MSC::MSC_SERIAL);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_abs(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_ABS(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_ABS(code) => match code {
+                EV_ABS::ABS_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_MSC(EV_MSC::MSC_SERIAL);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_abs(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_ABS(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_MSC(code) => {
-                match code {
-                    EV_MSC::MSC_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_SW(EV_SW::SW_LID);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_msc(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_MSC(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_MSC(code) => match code {
+                EV_MSC::MSC_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_SW(EV_SW::SW_LID);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_msc(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_MSC(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_SW(code) => {
-                match code {
-                    EV_SW::SW_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_LED(EV_LED::LED_NUML);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_sw(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_SW(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_SW(code) => match code {
+                EV_SW::SW_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_LED(EV_LED::LED_NUML);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_sw(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_SW(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_LED(code) => {
-                match code {
-                    EV_LED::LED_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_SND(EV_SND::SND_CLICK);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_led(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_LED(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_LED(code) => match code {
+                EV_LED::LED_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_SND(EV_SND::SND_CLICK);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_led(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_LED(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_SND(code) => {
-                match code {
-                    EV_SND::SND_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_REP(EV_REP::REP_DELAY);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_snd(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_SND(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_SND(code) => match code {
+                EV_SND::SND_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_REP(EV_REP::REP_DELAY);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_snd(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_SND(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_REP(code) => {
-                match code {
-                    EV_REP::REP_MAX => {
-                        let ev_code = self.current.clone();
-                        self.current = EventCode::EV_FF(EV_FF::FF_STATUS_STOPPED);
-                        return Some(ev_code);
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_rep(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_REP(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_REP(code) => match code {
+                EV_REP::REP_MAX => {
+                    let ev_code = self.current;
+                    self.current = EventCode::EV_FF(EV_FF::FF_STATUS_STOPPED);
+                    Some(ev_code)
+                }
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_rep(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_REP(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
             }
-            EventCode::EV_FF(code) => {
-                match code {
-                    EV_FF::FF_MAX => {
-                        return None
-                    }
-                    _ => {
-                        let mut raw_code = (code as u32) + 1;
-                        loop {
-                            match int_to_ev_ff(raw_code) {
-                                Some(x) => {
-                                    let ev_code = self.current.clone();
-                                    self.current = EventCode::EV_FF(x);
-                                    return Some(ev_code);
-                                }
-                                None => raw_code += 1,
+            EventCode::EV_FF(code) => match code {
+                EV_FF::FF_MAX => None,
+                _ => {
+                    let mut raw_code = (code as u32) + 1;
+                    loop {
+                        match int_to_ev_ff(raw_code) {
+                            Some(x) => {
+                                let ev_code = self.current;
+                                self.current = EventCode::EV_FF(x);
+                                return Some(ev_code);
                             }
+                            None => raw_code += 1,
                         }
                     }
                 }
-            }
+            },
             _ => None,
         }
     }
@@ -519,15 +443,13 @@ impl Iterator for InputPropIterator {
 
     fn next(&mut self) -> Option<InputProp> {
         match self.current {
-            InputProp::INPUT_PROP_MAX => {
-                return None;
-            }
+            InputProp::INPUT_PROP_MAX => None,
             _ => {
-                let mut raw_enum = (self.current.clone() as u32) + 1;
+                let mut raw_enum = (self.current as u32) + 1;
                 loop {
                     match int_to_input_prop(raw_enum) {
                         Some(x) => {
-                            let prop = self.current.clone();
+                            let prop = self.current;
                             self.current = x;
                             return Some(prop);
                         }
@@ -538,4 +460,3 @@ impl Iterator for InputPropIterator {
         }
     }
 }
-

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,8 @@ use log::warn;
 use std::fmt;
 use std::ffi::{CStr, CString};
 
+use evdev_sys as raw;
+
 pub(crate) unsafe fn ptr_to_str(ptr: *const c_char) -> Option<&'static str> {
     if ptr.is_null() {
         return None;
@@ -75,7 +77,7 @@ pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
 impl fmt::Display for EventType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", unsafe { ptr_to_str(
-            evdev_sys::libevdev_event_type_get_name(*self as c_uint)
+            raw::libevdev_event_type_get_name(*self as c_uint)
         )}.unwrap_or(""))
     }
 }
@@ -84,7 +86,7 @@ impl fmt::Display for EventCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (ev_type, ev_code) = event_code_to_int(self);
         write!(f, "{}", unsafe { ptr_to_str(
-            evdev_sys::libevdev_event_code_get_name(ev_type, ev_code)
+            raw::libevdev_event_code_get_name(ev_type, ev_code)
         )}.unwrap_or(""))
     }
 }
@@ -92,7 +94,7 @@ impl fmt::Display for EventCode {
 impl fmt::Display for InputProp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", unsafe { ptr_to_str(
-            evdev_sys::libevdev_property_get_name(*self as c_uint)
+            raw::libevdev_property_get_name(*self as c_uint)
         )}.unwrap_or(""))
     }
 }
@@ -106,7 +108,7 @@ impl EventType {
     pub fn from_str(name: &str) -> Option<EventType> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            evdev_sys::libevdev_event_type_from_name(name.as_ptr())
+            raw::libevdev_event_type_from_name(name.as_ptr())
         };
 
         match result {
@@ -119,7 +121,7 @@ impl EventType {
     /// of EV_ABS, or Errno for an invalid type.
     pub fn get_max(ev_type: &EventType) -> Option<i32> {
         let result = unsafe {
-            evdev_sys::libevdev_event_type_get_max(*ev_type as c_uint)
+            raw::libevdev_event_type_get_max(*ev_type as c_uint)
         };
 
         match result {
@@ -141,7 +143,7 @@ impl EventCode {
     pub fn from_str(ev_type: &EventType, name: &str) -> Option<EventCode> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            evdev_sys::libevdev_event_code_from_name(*ev_type as c_uint, name.as_ptr())
+            raw::libevdev_event_code_from_name(*ev_type as c_uint, name.as_ptr())
         };
 
         match result {
@@ -163,7 +165,7 @@ impl InputProp {
     pub fn from_str(name: &str) -> Option<InputProp> {
         let name = CString::new(name).unwrap();
         let result = unsafe {
-            evdev_sys::libevdev_property_from_name(name.as_ptr())
+            raw::libevdev_property_from_name(name.as_ptr())
         };
 
         match result {

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,56 +50,23 @@ pub fn event_code_to_int(event_code: &EventCode) -> (c_uint, c_uint) {
 
 pub fn int_to_event_code(event_type: c_uint, event_code: c_uint) -> EventCode {
     let ev_type: EventType = int_to_event_type(event_type as u32).unwrap();
+    let code = event_code as u32;
 
     let ev_code = match ev_type {
-        EventType::EV_SYN =>    match int_to_ev_syn(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_SYN(k)),
-                                },
-        EventType::EV_KEY =>    match int_to_ev_key(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_KEY(k)),
-
-                                },
-        EventType::EV_ABS =>    match int_to_ev_abs(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_ABS(k)),
-                                },
-        EventType::EV_REL =>    match int_to_ev_rel(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_REL(k)),
-                                },
-        EventType::EV_MSC =>    match int_to_ev_msc(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_MSC(k)),
-                                },
-        EventType::EV_SW =>     match int_to_ev_sw(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_SW(k)),
-                                },
-        EventType::EV_LED =>    match int_to_ev_led(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_LED(k)),
-                                },
-        EventType::EV_SND =>    match int_to_ev_snd(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_SND(k)),
-                                },
-        EventType::EV_REP =>    match int_to_ev_rep(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_REP(k)),
-                                },
-        EventType::EV_FF =>     match int_to_ev_ff(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_FF(k)),
-                                },
-        EventType::EV_PWR =>    Some(EventCode::EV_PWR),
-        EventType::EV_FF_STATUS => match int_to_ev_ff(event_code as u32) {
-                                    None => None,
-                                    Some(k) => Some(EventCode::EV_FF_STATUS(k)),
-                                },
-        EventType::EV_UNK =>    None,
-        EventType::EV_MAX =>    Some(EventCode::EV_MAX),
+        EventType::EV_SYN => int_to_ev_syn(code).map(EventCode::EV_SYN),
+        EventType::EV_KEY => int_to_ev_key(code).map(EventCode::EV_KEY),
+        EventType::EV_ABS => int_to_ev_abs(code).map(EventCode::EV_ABS),
+        EventType::EV_REL => int_to_ev_rel(code).map(EventCode::EV_REL),
+        EventType::EV_MSC => int_to_ev_msc(code).map(EventCode::EV_MSC),
+        EventType::EV_SW => int_to_ev_sw(code).map(EventCode::EV_SW),
+        EventType::EV_LED => int_to_ev_led(code).map(EventCode::EV_LED),
+        EventType::EV_SND => int_to_ev_snd(code).map(EventCode::EV_SND),
+        EventType::EV_REP => int_to_ev_rep(code).map(EventCode::EV_REP),
+        EventType::EV_FF => int_to_ev_ff(code).map(EventCode::EV_FF),
+        EventType::EV_PWR => Some(EventCode::EV_PWR),
+        EventType::EV_FF_STATUS => int_to_ev_ff(code).map(EventCode::EV_FF_STATUS),
+        EventType::EV_UNK => None,
+        EventType::EV_MAX => Some(EventCode::EV_MAX),
     };
 
     ev_code.unwrap_or(EventCode::EV_UNK {event_type, event_code})

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,7 +1,5 @@
-extern crate evdev_rs as evdev;
-
-use evdev::*;
-use evdev::enums::*;
+use evdev_rs::*;
+use evdev_rs::enums::*;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 

--- a/tools/make-event-names.py
+++ b/tools/make-event-names.py
@@ -82,7 +82,7 @@ def print_enums(bits, prefix):
 
         print("#[allow(non_camel_case_types)]")
         print('#[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]')
-        print("#[derive(Clone, Debug, PartialEq, Eq, Hash)]")
+        print("#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]")
         print("pub enum %s {" % enum_name)
         for val, names in list(getattr(bits, prefix).items()):
             # Note(ndesh): We use EV_MAX as proxy to write the UNKnown event
@@ -141,7 +141,7 @@ def print_event_code(bits, prefix):
 
         print("#[allow(non_camel_case_types)]")
         print('#[cfg_attr(feature = "serde", derive(Serialize), derive(Deserialize))]')
-        print("#[derive(Clone, Debug, PartialEq)]")
+        print("#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]")
         print("pub enum EventCode {")
         for val, [name] in list(getattr(bits, prefix).items()):
             if name[3:]+"_" in event_names:
@@ -251,6 +251,8 @@ if __name__ == "__main__":
 
         print("/* THIS FILE IS GENERATED, DO NOT EDIT */")
         print("")
+        print('#[cfg(feature = "serde")]')
+        print("use serde::{Serialize, Deserialize};")
 
         if len(sys.argv) == 2:
                 with open(sys.argv[1]) as f:


### PR DESCRIPTION
All changes mase are non-breaking
Replace tabs with 4 spaces where tabs were mixed with spaces
Update to rust 2018 edition
Fix some cargo clippy lints
Added more derives to enums.rs (through python ffi script)