### PR TITLE
don't export the same item under different paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,10 @@
 
 #[macro_use]
 mod macros;
-pub mod device;
+mod device;
 pub mod enums;
 pub mod logging;
-pub mod uinput;
+mod uinput;
 pub mod util;
 
 use bitflags::bitflags;


### PR DESCRIPTION
remove duplicate exports by way of pub mod in addition to pub use within
the crate root. Fixes issue #69.