### PR TITLE
Implement AsRawFd for Device

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -789,6 +789,12 @@ impl Device {
     }
 }
 
+impl AsRawFd for Device {
+    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
 impl Drop for Device {
     fn drop(&mut self) {
         unsafe {

--- a/src/device.rs
+++ b/src/device.rs
@@ -527,6 +527,7 @@ pub struct Device {
 }
 
 unsafe impl Send for Device {}
+unsafe impl Sync for Device {}
 
 impl DeviceWrapper for Device {
     fn raw(&self) -> *mut raw::libevdev {


### PR DESCRIPTION
provides compatibility with `smol::Async` for polling from async contexts:

```rust
// Setup async device wrapper (configures device file descriptor with `O_NONBLOCK`)
let a = smol::Async::new(d)?;

// Async poll for the next event
let (_status, event) = a.read_with(|d| d.next_event(ReadFlag::NORMAL) ).await?;
```

for convenience `Device` also really needs to be `Sync`, which it is not automatically due to the internal `*mut raw::libevdev`, however, i can't see from the evdev docs whether this is reasonable or not?