### PR TITLE
Implement Debug for pub structs

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -577,6 +577,16 @@ impl Drop for UninitDevice {
     }
 }
 
+impl std::fmt::Debug for UninitDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("UninitDevice")
+            .field("name", &self.name())
+            .field("phys", &self.phys())
+            .field("uniq", &self.uniq())
+            .finish()
+    }
+}
+
 /// Opaque struct representing an evdev device
 ///
 /// Unlike libevdev, this `Device` mantains an associated file as an invariant
@@ -853,5 +863,15 @@ impl Drop for Device {
         unsafe {
             raw::libevdev_free(self.raw);
         }
+    }
+}
+
+impl std::fmt::Debug for Device {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Device")
+            .field("name", &self.name())
+            .field("phys", &self.phys())
+            .field("uniq", &self.uniq())
+            .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub enum LedState {
     Off = raw::LIBEVDEV_LED_OFF as isize,
 }
 
+#[derive(Debug)]
 pub struct DeviceId {
     pub bustype: BusType,
     pub vendor: u16,
@@ -123,6 +124,7 @@ pub struct DeviceId {
     pub version: u16,
 }
 
+#[derive(Debug)]
 /// used by EVIOCGABS/EVIOCSABS ioctls
 pub struct AbsInfo {
     /// latest reported value for the axis

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -109,3 +109,11 @@ impl Drop for UInputDevice {
         }
     }
 }
+
+impl std::fmt::Debug for UInputDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("UInputDevice")
+            .field("devnode", &self.devnode())
+            .finish()
+    }
+}


### PR DESCRIPTION
Implemented for Device, UninitDevice, UInputDevice, DeviceId, and AbsInfo, which should mean that all public structs should impl Debug.

Fixes #71.