### PR TITLE
build.rs: fix cargo:rerun-if-changed setting

### DIFF
--- a/evdev-sys/build.rs
+++ b/evdev-sys/build.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}/include", dst.display());
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=libevdev");
 
     println!("cargo:rustc-link-lib=static=evdev");
     let cfg = cc::Build::new();

--- a/evdev-sys/build.rs
+++ b/evdev-sys/build.rs
@@ -69,10 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rustc-link-search={}/lib", dst.display());
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}/include", dst.display());
-    println!(
-        "cargo:rerun-if-changed={}/libevdev/autogen.sh",
-        dst.display()
-    );
+    println!("cargo:rerun-if-changed=build.rs");
 
     println!("cargo:rustc-link-lib=static=evdev");
     let cfg = cc::Build::new();


### PR DESCRIPTION
I reported #88 a few days ago and decided to give it another shot today. I noticed that `build.rs` was outputting `cargo:rerun-if-changed` in its stdout and took at look at the build logs. I found the following line in one of my builds:

```
cargo:rerun-if-changed=/home/wayne/projects/evdev-rs/target/debug/build/evdev-sys-6fd4f6905943f796/out/libevdev/autogen.sh
```

It seems kind of counterintuitive to me that cargo should check the build directory for things that have changed so I grepped to see what other dependencies might be doing with this variable:

```
zsh/3 3447  (git)-[master]-% rg 'rerun-if-changed' target
target/debug/build/evdev-sys-6fd4f6905943f796/output
5:cargo:rerun-if-changed=/home/wayne/projects/evdev-rs/target/debug/build/evdev-sys-6fd4f6905943f796/out/libevdev/autogen.sh

target/debug/build/libc-de081291a2d6ae6e/output
1:cargo:rerun-if-changed=build.rs

target/debug/build/evdev-sys-99cb02000f00afc4/output
4:cargo:rerun-if-changed=/home/wayne/projects/evdev-rs/target/debug/build/evdev-sys-99cb02000f00afc4/out/libevdev/autogen.sh

target/debug/build/log-77e644f83eaeb617/output
2:cargo:rerun-if-changed=build.rs
```

So it looks like other projects are referring to `build.rs` itself. I can see how this would make sense for some projects, but maybe it doesn't for `evdev-sys` for whatever reason. But still, I decided to give it a shot here and it did indeed fix the problem!

But now I'm wondering if maybe the path should actually be `libevdev/autogen.sh` since cargo probably already tracks files in the current project/crate. Or maybe `libevdev` since any thing could change in that submodule, not just `autogen.sh`. I'll leave that decision up to the maintainers -- just let me know what you'd like me to change!