### PR TITLE
Make EnableCodeData public + copiable/clonable

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -68,6 +68,7 @@ impl Enable for EventCode {
 }
 
 /// Extra data for use with enable_event_code
+#[derive(Clone, Copy, Debug)]
 pub enum EnableCodeData {
     AbsInfo(AbsInfo),
     RepInfo(i32),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub struct DeviceId {
     pub version: u16,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 /// used by EVIOCGABS/EVIOCSABS ioctls
 pub struct AbsInfo {
     /// latest reported value for the axis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@ pub use device::DeviceWrapper;
 #[doc(inline)]
 pub use device::Enable;
 #[doc(inline)]
+pub use device::EnableCodeData;
+#[doc(inline)]
 pub use device::UninitDevice;
 #[doc(inline)]
 pub use uinput::UInputDevice;


### PR DESCRIPTION
1. #70 as introduced `EnableCodeData` in `DeviceWrapper::enable_event_code()`. But the enum isn't reexported in `lib.rs`, so it can't be used because `device.rs` is a private module.
2. Make `EnableCodeData` implement `Copy` and `Clone`