### PR TITLE
evdev-rs: introduce *Iterator::new()

### DIFF
--- a/examples/evtest.rs
+++ b/examples/evtest.rs
@@ -30,11 +30,8 @@ fn print_abs_bits(dev: &Device, axis: &EV_ABS) {
     }
 }
 
-fn print_code_bits(dev: &Device, ev_code: &EventCode, max: &EventCode) {
-    for code in ev_code.iter() {
-        if code == *max {
-            break;
-        }
+fn print_code_bits(dev: &Device, ev_type: &EventType) {
+    for code in EventCodeIterator::new(ev_type) {
         if !dev.has(code) {
             continue;
         }
@@ -50,32 +47,16 @@ fn print_code_bits(dev: &Device, ev_code: &EventCode, max: &EventCode) {
 fn print_bits(dev: &Device) {
     println!("Supported events:");
 
-    for ev_type in EventType::EV_SYN.iter() {
+    for ev_type in EventTypeIterator::new() {
         if dev.has(ev_type) {
             println!("  Event type: {} ", ev_type);
         }
 
         match ev_type {
-            EventType::EV_KEY => print_code_bits(
-                dev,
-                &EventCode::EV_KEY(EV_KEY::KEY_RESERVED),
-                &EventCode::EV_KEY(EV_KEY::KEY_MAX),
-            ),
-            EventType::EV_REL => print_code_bits(
-                dev,
-                &EventCode::EV_REL(EV_REL::REL_X),
-                &EventCode::EV_REL(EV_REL::REL_MAX),
-            ),
-            EventType::EV_ABS => print_code_bits(
-                dev,
-                &EventCode::EV_ABS(EV_ABS::ABS_X),
-                &EventCode::EV_ABS(EV_ABS::ABS_MAX),
-            ),
-            EventType::EV_LED => print_code_bits(
-                dev,
-                &EventCode::EV_LED(EV_LED::LED_NUML),
-                &EventCode::EV_LED(EV_LED::LED_MAX),
-            ),
+            EventType::EV_KEY
+            | EventType::EV_REL
+            | EventType::EV_ABS
+            | EventType::EV_LED => print_code_bits(dev, &ev_type),
             _ => (),
         }
     }
@@ -84,7 +65,7 @@ fn print_bits(dev: &Device) {
 fn print_props(dev: &Device) {
     println!("Properties:");
 
-    for input_prop in InputProp::INPUT_PROP_POINTER.iter() {
+    for input_prop in InputPropIterator::new() {
         if dev.has_property(&input_prop) {
             println!("  Property type: {}", input_prop);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@ use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
 use enums::*;
 use util::*;
 
+pub use util::EventCodeIterator;
+pub use util::EventTypeIterator;
+pub use util::InputPropIterator;
+
 use evdev_sys as raw;
 
 #[doc(inline)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,6 +24,45 @@ pub struct InputPropIterator {
     current: InputProp,
 }
 
+impl EventTypeIterator {
+    pub fn new() -> Self {
+        EventTypeIterator {
+            current: EventType::EV_SYN,
+        }
+    }
+}
+
+impl EventCodeIterator {
+    pub fn new(event_type: &EventType) -> Self {
+        let event_code = match *event_type {
+            EventType::EV_SYN => EventCode::EV_SYN(EV_SYN::SYN_REPORT),
+            EventType::EV_KEY => EventCode::EV_KEY(EV_KEY::KEY_RESERVED),
+            EventType::EV_REL => EventCode::EV_REL(EV_REL::REL_X),
+            EventType::EV_ABS => EventCode::EV_ABS(EV_ABS::ABS_X),
+            EventType::EV_MSC => EventCode::EV_MSC(EV_MSC::MSC_SERIAL),
+            EventType::EV_SW => EventCode::EV_SW(EV_SW::SW_LID),
+            EventType::EV_LED => EventCode::EV_LED(EV_LED::LED_NUML),
+            EventType::EV_SND => EventCode::EV_SND(EV_SND::SND_CLICK),
+            EventType::EV_REP => EventCode::EV_REP(EV_REP::REP_DELAY),
+            EventType::EV_FF => EventCode::EV_FF(EV_FF::FF_STATUS_STOPPED),
+            EventType::EV_FF_STATUS => EventCode::EV_FF_STATUS(EV_FF::FF_STATUS_STOPPED),
+            _ => EventCode::EV_MAX,
+        };
+
+        EventCodeIterator {
+            current: event_code,
+        }
+    }
+}
+
+impl InputPropIterator {
+    pub fn new() -> Self {
+        InputPropIterator {
+            current: InputProp::INPUT_PROP_POINTER,
+        }
+    }
+}
+
 pub fn event_code_to_int(event_code: &EventCode) -> (c_uint, c_uint) {
     match *event_code {
         EventCode::EV_SYN(code) => (EventType::EV_SYN as c_uint, code as c_uint),
@@ -213,11 +252,7 @@ impl Iterator for EventCodeIterator {
     fn next(&mut self) -> Option<EventCode> {
         match self.current {
             EventCode::EV_SYN(code) => match code {
-                EV_SYN::SYN_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_KEY(EV_KEY::KEY_RESERVED);
-                    Some(ev_code)
-                }
+                EV_SYN::SYN_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -233,11 +268,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_KEY(code) => match code {
-                EV_KEY::KEY_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_REL(EV_REL::REL_X);
-                    Some(ev_code)
-                }
+                EV_KEY::KEY_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -253,11 +284,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_REL(code) => match code {
-                EV_REL::REL_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_ABS(EV_ABS::ABS_X);
-                    Some(ev_code)
-                }
+                EV_REL::REL_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -273,11 +300,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_ABS(code) => match code {
-                EV_ABS::ABS_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_MSC(EV_MSC::MSC_SERIAL);
-                    Some(ev_code)
-                }
+                EV_ABS::ABS_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -293,11 +316,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_MSC(code) => match code {
-                EV_MSC::MSC_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_SW(EV_SW::SW_LID);
-                    Some(ev_code)
-                }
+                EV_MSC::MSC_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -313,11 +332,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_SW(code) => match code {
-                EV_SW::SW_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_LED(EV_LED::LED_NUML);
-                    Some(ev_code)
-                }
+                EV_SW::SW_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -333,11 +348,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_LED(code) => match code {
-                EV_LED::LED_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_SND(EV_SND::SND_CLICK);
-                    Some(ev_code)
-                }
+                EV_LED::LED_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -353,11 +364,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_SND(code) => match code {
-                EV_SND::SND_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_REP(EV_REP::REP_DELAY);
-                    Some(ev_code)
-                }
+                EV_SND::SND_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {
@@ -373,11 +380,7 @@ impl Iterator for EventCodeIterator {
                 }
             },
             EventCode::EV_REP(code) => match code {
-                EV_REP::REP_MAX => {
-                    let ev_code = self.current;
-                    self.current = EventCode::EV_FF(EV_FF::FF_STATUS_STOPPED);
-                    Some(ev_code)
-                }
+                EV_REP::REP_MAX => None,
                 _ => {
                     let mut raw_code = (code as u32) + 1;
                     loop {


### PR DESCRIPTION
Having a constructor for iterator allows for a more
object oriented policy which exposes a more higher
level API.

This patch changes the behavior of EventCodeIterator,
which was previously iterating over all the event codes
but now it only iterates over the event code for a
particular event type.

closes #50

Signed-off-by: Nayan Deshmukh <nayan26deshmukh@gmail.com>