### PR TITLE
Update to bitflags2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libevdev-1-10 = ["evdev-sys/libevdev-1-10"]
 serde = { version = "1.0", default-features = false, features=["derive"], optional = true }
 evdev-sys = { path = "evdev-sys", version = "0.2.5" }
 libc = "0.2.67"
-bitflags = "1.2.1"
+bitflags = "2.4.1"
 log = "0.4.8"
 
 [package.metadata.docs.rs]

--- a/src/device.rs
+++ b/src/device.rs
@@ -877,8 +877,9 @@ impl Device {
             value: 0,
         };
 
-        let result =
-            unsafe { raw::libevdev_next_event(self.raw, flags.bits as c_uint, &mut ev) };
+        let result = unsafe {
+            raw::libevdev_next_event(self.raw, flags.bits() as c_uint, &mut ev)
+        };
 
         let event = InputEvent {
             time: TimeVal {


### PR DESCRIPTION
The update to bitflags2 required minimal work.

I can't find any details of any MSRV policy you might have, so I did not check that (only tested on Rust 1.74.0). Unit tests pass (some only with sudo due to permissions, but it was the same before this change).

This resolves #103 

After this a new release would need to be made as well.