### PR TITLE
Implemented Sync for UInputDevice to enable sharing among threads

### DIFF
--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -12,6 +12,7 @@ pub struct UInputDevice {
     raw: *mut raw::libevdev_uinput,
 }
 
+unsafe impl Sync for UInputDevice {}
 unsafe impl Send for UInputDevice {}
 
 impl UInputDevice {


### PR DESCRIPTION
This PR implements `Sync` for `UInputDevice` to allow it to be shared among threads. The code already implemented `Send` to send to another thread, so this increases the contexts in which one can use a `UInputDevice`.