### PR TITLE
Reintroduce Copy and Clone traits for ReadFlag (#116)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub enum GrabMode {
 }
 
 bitflags! {
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct ReadFlag: u32 {
         /// Process data in sync mode
         const SYNC = 1;


### PR DESCRIPTION
The traits were removed unintentionally when bitflag was updated to v2 as part of 0.6.2 release. The v2 removes the automatic derivation of certain traits. I'm putting back all the traits that were removed in order to not break any code that relied on it.