### PR TITLE
evdev-rs: Enforce proper type for tv_usec / MICROS_PER_SEC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl TimeVal {
     pub const fn new(tv_sec: time_t, tv_usec: suseconds_t) -> TimeVal {
         const MICROS_PER_SEC: suseconds_t = 1_000_000;
         TimeVal {
-            tv_sec: tv_sec + tv_usec / MICROS_PER_SEC,
+            tv_sec: tv_sec + (tv_usec / MICROS_PER_SEC) as time_t,
             tv_usec: tv_usec % MICROS_PER_SEC,
         }
     }


### PR DESCRIPTION
On sparc64, suseconds_t is of type i32 while tv_sec is of type time_t which itself is of type i64 which causes the build on sparc64 to fail:

error[E0308]: mismatched types
   --> src/lib.rs:210:30
    |
210 |             tv_sec: tv_sec + tv_usec / MICROS_PER_SEC,
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^ expected `i64`, found `i32`

error[E0277]: cannot add `i32` to `i64`
   --> src/lib.rs:210:28
    |
210 |             tv_sec: tv_sec + tv_usec / MICROS_PER_SEC,
    |                            ^ no implementation for `i64 + i32`
    |
    = help: the trait `Add<i32>` is not implemented for `i64`
    = help: the following other types implement trait `Add<Rhs>`:
              `&i64` implements `Add<i64>`
              `&i64` implements `Add`
              `i64` implements `Add<&i64>`
              `i64` implements `Add`

The type mismatch for suseconds_t is a result of binary compatibility with Solaris and cannot be changed as it's part of the ABI. Since the values for suseconds_t never exceed 32-bit boundaries, it's not really a problem and we can safely cast tv_usec / MICROS_PER_SEC to time_t to fix the build on sparc64.